### PR TITLE
add base keys in the end of a table and more optimizations

### DIFF
--- a/db.go
+++ b/db.go
@@ -762,7 +762,7 @@ func arenaSize(opt Options) int64 {
 func writeLevel0Table(s *skl.Skiplist, f *os.File) error {
 	iter := s.NewIterator()
 	defer iter.Close()
-	b := table.NewTableBuilder()
+	b := table.NewTableBuilder(s.MemSize())
 	defer b.Close()
 	for iter.SeekToFirst(); iter.Valid(); iter.Next() {
 		if err := b.Add(iter.Key(), iter.Value()); err != nil {

--- a/levels.go
+++ b/levels.go
@@ -323,7 +323,7 @@ func (s *levelsController) compactBuildTables(
 	var lastKey, skipKey []byte
 	for it.Valid() {
 		timeStart := time.Now()
-		builder := table.NewTableBuilder()
+		builder := table.NewTableBuilder(s.kv.opt.MaxTableSize)
 		var numKeys, numSkips uint64
 		for ; it.Valid(); it.Next() {
 			// See if we need to skip this key.

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -122,7 +122,7 @@ func buildTestTable(t *testing.T, prefix string, n int) *os.File {
 // TODO - Move these to somewhere where table package can also use it.
 // keyValues is n by 2 where n is number of pairs.
 func buildTable(t *testing.T, keyValues [][]string) *os.File {
-	b := table.NewTableBuilder()
+	b := table.NewTableBuilder(0)
 	defer b.Close()
 	// TODO: Add test for file garbage collection here. No files should be left after the tests here.
 

--- a/skl/arena.go
+++ b/skl/arena.go
@@ -68,9 +68,7 @@ func (s *Arena) putNode(height int) uint32 {
 	// Pad the allocation with enough bytes to ensure pointer alignment.
 	l := uint32(MaxNodeSize - unusedSize + nodeAlign)
 	n := atomic.AddUint32(&s.n, l)
-	y.AssertTruef(int(n) <= len(s.buf),
-		"Arena too small, toWrite:%d newTotal:%d limit:%d",
-		l, n, len(s.buf))
+	y.AssertTrue(int(n) <= len(s.buf))
 
 	// Return the aligned offset.
 	m := (n - l + uint32(nodeAlign)) & ^uint32(nodeAlign)
@@ -84,9 +82,7 @@ func (s *Arena) putNode(height int) uint32 {
 func (s *Arena) putVal(v y.ValueStruct) uint32 {
 	l := uint32(v.EncodedSize())
 	n := atomic.AddUint32(&s.n, l)
-	y.AssertTruef(int(n) <= len(s.buf),
-		"Arena too small, toWrite:%d newTotal:%d limit:%d",
-		l, n, len(s.buf))
+	y.AssertTrue(int(n) <= len(s.buf))
 	m := n - l
 	v.Encode(s.buf[m:])
 	return m
@@ -95,9 +91,7 @@ func (s *Arena) putVal(v y.ValueStruct) uint32 {
 func (s *Arena) putKey(key []byte) uint32 {
 	l := uint32(len(key))
 	n := atomic.AddUint32(&s.n, l)
-	y.AssertTruef(int(n) <= len(s.buf),
-		"Arena too small, toWrite:%d newTotal:%d limit:%d",
-		l, n, len(s.buf))
+	y.AssertTrue(int(n) <= len(s.buf))
 	m := n - l
 	y.AssertTrue(len(key) == copy(s.buf[m:n], key))
 	return m

--- a/skl/skl.go
+++ b/skl/skl.go
@@ -336,7 +336,7 @@ func (s *Skiplist) Put(key []byte, v y.ValueStruct) {
 			// because it is unlikely that lots of nodes are inserted between prev[i] and next[i].
 			prev[i], next[i] = s.findSpliceForLevel(key, prev[i], i)
 			if prev[i] == next[i] {
-				y.AssertTruef(i == 0, "Equality can happen only on base level: %d", i)
+				y.AssertTrue(i == 0)
 				prev[i].setValue(s.arena, v)
 				return
 			}

--- a/table/builder.go
+++ b/table/builder.go
@@ -158,12 +158,12 @@ func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 // at the end. The diff can vary.
 
 // ReachedCapacity returns true if we... roughly (?) reached capacity?
-func (b *Builder) ReachedCapacity(cap int64) bool {
+func (b *Builder) ReachedCapacity(capacity int64) bool {
 	estimateSz := len(b.buf) +
 		4*len(b.blockEndOffsets) +
 		len(b.baseKeysBuf) +
 		4*len(b.baseKeysEndOffs)
-	return int64(estimateSz) > cap
+	return int64(estimateSz) > capacity
 }
 
 // Finish finishes the table by appending the index.
@@ -203,4 +203,8 @@ func bytesToU32Slice(b []byte) []uint32 {
 	hdr.Cap = hdr.Len
 	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
 	return u32s
+}
+
+func bytesToU32(b []byte) uint32 {
+	return binary.LittleEndian.Uint32(b)
 }

--- a/table/builder.go
+++ b/table/builder.go
@@ -17,81 +17,66 @@
 package table
 
 import (
-	"bytes"
 	"encoding/binary"
-	"io"
-	"math"
+	"reflect"
+	"unsafe"
 
 	"github.com/coocood/badger/y"
 	"github.com/coocood/bbloom"
 )
 
-var (
-	restartInterval = 100 // Might want to change this to be based on total size instead of numKeys.
-)
-
-func newBuffer(sz int) *bytes.Buffer {
-	b := new(bytes.Buffer)
-	b.Grow(sz)
-	return b
-}
+const restartInterval = 256 // Might want to change this to be based on total size instead of numKeys.
 
 type header struct {
 	plen uint16 // Overlap with base key.
 	klen uint16 // Length of the diff.
-	vlen uint16 // Length of value.
-	prev uint32 // Offset for the previous key-value pair. The offset is relative to block base offset.
 }
 
 // Encode encodes the header.
-func (h header) Encode(b []byte) {
-	binary.BigEndian.PutUint16(b[0:2], h.plen)
-	binary.BigEndian.PutUint16(b[2:4], h.klen)
-	binary.BigEndian.PutUint16(b[4:6], h.vlen)
-	binary.BigEndian.PutUint32(b[6:10], h.prev)
+func (h header) Encode() []byte {
+	var b [4]byte
+	*(*header)(unsafe.Pointer(&b[0])) = h
+	return b[:]
 }
 
 // Decode decodes the header.
-func (h *header) Decode(buf []byte) int {
-	h.plen = binary.BigEndian.Uint16(buf[0:2])
-	h.klen = binary.BigEndian.Uint16(buf[2:4])
-	h.vlen = binary.BigEndian.Uint16(buf[4:6])
-	h.prev = binary.BigEndian.Uint32(buf[6:10])
-	return h.Size()
+func (h *header) Decode(buf []byte) {
+	*h = *(*header)(unsafe.Pointer(&buf[0]))
 }
 
-// Size returns size of the header. Currently it's just a constant.
-func (h header) Size() int { return 10 }
+const headerSize = 4
 
 // Builder is used in building a table.
 type Builder struct {
 	counter int // Number of keys written for the current block.
 
 	// Typically tens or hundreds of meg. This is for one single file.
-	buf *bytes.Buffer
+	buf []byte
 
-	baseKey    []byte // Base key for the current block.
-	baseOffset uint32 // Offset for the current block.
+	baseKeysBuf     []byte
+	baseKeysEndOffs []uint32
 
-	restarts []uint32 // Base offsets of every block.
+	blockBaseKey    []byte // Base key for the current block.
+	blockBaseOffset uint32 // Offset for the current block.
 
-	// Offsets of every entry within the current block being built.
+	blockEndOffsets []uint32 // Base offsets of every block.
+
+	// end offsets of every entry within the current block being built.
 	// The offsets are relative to the start of the block.
-	entryOffsets []uint32
+	entryEndOffsets []uint32
 
-	// Tracks offset for the previous key-value pair. Offset is relative to block base offset.
-	prevOffset uint32
-
-	keyBuf   *bytes.Buffer
-	keyCount int
+	bloomFilter bbloom.Bloom
 }
 
 // NewTableBuilder makes a new TableBuilder.
-func NewTableBuilder() *Builder {
+// The initCap is used to avoid memory reallocation.
+func NewTableBuilder(initCap int64) *Builder {
+	assumeKeyNum := 256 * 1024
 	return &Builder{
-		keyBuf:     newBuffer(1 << 20),
-		buf:        newBuffer(1 << 20),
-		prevOffset: math.MaxUint32, // Used for the first element!
+		buf:         make([]byte, 0, initCap),
+		baseKeysBuf: make([]byte, 0, assumeKeyNum/restartInterval),
+		// assume a large enough num of keys to init bloom filter.
+		bloomFilter: bbloom.New(float64(assumeKeyNum), 0.01),
 	}
 }
 
@@ -99,13 +84,13 @@ func NewTableBuilder() *Builder {
 func (b *Builder) Close() {}
 
 // Empty returns whether it's empty.
-func (b *Builder) Empty() bool { return b.buf.Len() == 0 }
+func (b *Builder) Empty() bool { return len(b.buf) == 0 }
 
-// keyDiff returns a suffix of newKey that is different from b.baseKey.
+// keyDiff returns a suffix of newKey that is different from b.blockBaseKey.
 func (b Builder) keyDiff(newKey []byte) []byte {
 	var i int
-	for i = 0; i < len(newKey) && i < len(b.baseKey); i++ {
-		if newKey[i] != b.baseKey[i] {
+	for i = 0; i < len(newKey) && i < len(b.blockBaseKey); i++ {
+		if newKey[i] != b.blockBaseKey[i] {
 			break
 		}
 	}
@@ -115,20 +100,16 @@ func (b Builder) keyDiff(newKey []byte) []byte {
 func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	// Add key to bloom filter.
 	if len(key) > 0 {
-		var klen [2]byte
 		keyNoTs := y.ParseKey(key)
-		binary.BigEndian.PutUint16(klen[:], uint16(len(keyNoTs)))
-		b.keyBuf.Write(klen[:])
-		b.keyBuf.Write(keyNoTs)
-		b.keyCount++
+		b.bloomFilter.Add(keyNoTs)
 	}
 
-	// diffKey stores the difference of key with baseKey.
+	// diffKey stores the difference of key with blockBaseKey.
 	var diffKey []byte
-	if len(b.baseKey) == 0 {
+	if len(b.blockBaseKey) == 0 {
 		// Make a copy. Builder should not keep references. Otherwise, caller has to be very careful
 		// and will have to make copies of keys every time they add to builder, which is even worse.
-		b.baseKey = append(b.baseKey[:0], key...)
+		b.blockBaseKey = append(b.blockBaseKey[:0], key...)
 		diffKey = key
 	} else {
 		diffKey = b.keyDiff(key)
@@ -137,32 +118,28 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	h := header{
 		plen: uint16(len(key) - len(diffKey)),
 		klen: uint16(len(diffKey)),
-		vlen: uint16(v.EncodedSize()),
-		prev: b.prevOffset, // prevOffset is the location of the last key-value added.
 	}
-	b.prevOffset = uint32(b.buf.Len()) - b.baseOffset // Remember current offset for the next Add call.
-
-	b.entryOffsets = append(b.entryOffsets, uint32(b.buf.Len())-b.baseOffset)
-
-	// Layout: header, diffKey, value.
-	var hbuf [10]byte
-	h.Encode(hbuf[:])
-	b.buf.Write(hbuf[:])
-	b.buf.Write(diffKey) // We only need to store the key difference.
-
-	v.EncodeTo(b.buf)
+	b.buf = append(b.buf, h.Encode()...)
+	b.buf = append(b.buf, diffKey...) // We only need to store the key difference.
+	b.buf = v.EncodeTo(b.buf)
+	b.entryEndOffsets = append(b.entryEndOffsets, uint32(len(b.buf))-b.blockBaseOffset)
 	b.counter++ // Increment number of keys added for this current block.
 }
 
 func (b *Builder) finishBlock() {
-	// When we are at the end of the block and Valid=false, and the user wants to do a Prev,
-	// we need a dummy header to tell us the offset of the previous key-value pair.
-	b.addHelper([]byte{}, y.ValueStruct{})
+	b.buf = append(b.buf, u32SliceToBytes(b.entryEndOffsets)...)
+	b.buf = append(b.buf, u32ToBytes(uint32(len(b.entryEndOffsets)))...)
+	b.blockEndOffsets = append(b.blockEndOffsets, uint32(len(b.buf)))
 
-	b.buf.Write(b.entryIndex())
-	// Reset the entry offsets of the block for the next build.
-	b.entryOffsets = nil
+	// Add base key.
+	b.baseKeysBuf = append(b.baseKeysBuf, b.blockBaseKey...)
+	b.baseKeysEndOffs = append(b.baseKeysEndOffs, uint32(len(b.baseKeysBuf)))
 
+	// Reset the block for the next build.
+	b.entryEndOffsets = b.entryEndOffsets[:0]
+	b.counter = 0
+	b.blockBaseKey = b.blockBaseKey[:0]
+	b.blockBaseOffset = uint32(len(b.buf))
 }
 
 // Add adds a key-value pair to the block.
@@ -170,12 +147,6 @@ func (b *Builder) finishBlock() {
 func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 	if b.counter >= restartInterval {
 		b.finishBlock()
-		// Start a new block. Initialize the block.
-		b.restarts = append(b.restarts, uint32(b.buf.Len()))
-		b.counter = 0
-		b.baseKey = []byte{}
-		b.baseOffset = uint32(b.buf.Len())
-		b.prevOffset = math.MaxUint32 // First key-value pair of block has header.prev=MaxInt.
 	}
 	b.addHelper(key, value)
 	return nil // Currently, there is no meaningful error.
@@ -188,85 +159,48 @@ func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 
 // ReachedCapacity returns true if we... roughly (?) reached capacity?
 func (b *Builder) ReachedCapacity(cap int64) bool {
-	estimateSz := b.buf.Len() + 8 /* empty header */ + 4*len(b.restarts) + 8 // 8 = end of buf offset + len(restarts).
+	estimateSz := len(b.buf) +
+		4*len(b.blockEndOffsets) +
+		len(b.baseKeysBuf) +
+		4*len(b.baseKeysEndOffs)
 	return int64(estimateSz) > cap
-}
-
-// blockIndex generates the block index for the table.
-// It is mainly a list of all the block base offsets.
-func (b *Builder) blockIndex() []byte {
-	// Store the end offset, so we know the length of the final block.
-	b.restarts = append(b.restarts, uint32(b.buf.Len()))
-
-	// Add 4 because we want to write out number of restarts at the end.
-	sz := 4*len(b.restarts) + 4
-	out := make([]byte, sz)
-	buf := out
-	for _, r := range b.restarts {
-		binary.BigEndian.PutUint32(buf[:4], r)
-		buf = buf[4:]
-	}
-	binary.BigEndian.PutUint32(buf[:4], uint32(len(b.restarts)))
-	return out
-}
-
-// entryIndex generates the entry index for the block
-// (in a analogous way to `blockIndex`).
-// It is mainly a list of all the entry offsets.
-func (b *Builder) entryIndex() []byte {
-	// Remove the last (dummy) header added in `finishBlock`, it
-	// is used for the reverse iteration system and is not necessary
-	// in the entry offsets vector that will be used by the block iterator's
-	// `seek`.
-	// TODO: Remove this once the `Prev` and related fuctions are modified
-	// to leverage this entry index (and the dummy header is not added anymore).
-	b.entryOffsets = b.entryOffsets[:len(b.entryOffsets)-1]
-
-	// Add 4 because we want to write out the length of the index at the end.
-	index := make([]byte, 4*len(b.entryOffsets)+4)
-	buf := index
-	for _, offset := range b.entryOffsets {
-		binary.BigEndian.PutUint32(buf[:4], offset)
-		buf = buf[4:]
-	}
-	// Write the number of entry offsets (not the number of bytes),
-	// to be read in `loadEntryIndex`.
-	binary.BigEndian.PutUint32(buf[:4], uint32(len(b.entryOffsets)))
-
-	return index
 }
 
 // Finish finishes the table by appending the index.
 func (b *Builder) Finish() []byte {
-	bf := bbloom.New(float64(b.keyCount), 0.01)
-	var klen [2]byte
-	key := make([]byte, 1024)
-	for {
-		if _, err := b.keyBuf.Read(klen[:]); err == io.EOF {
-			break
-		} else if err != nil {
-			y.Check(err)
-		}
-		kl := int(binary.BigEndian.Uint16(klen[:]))
-		if cap(key) < kl {
-			key = make([]byte, 2*int(kl)) // 2 * uint16 will overflow
-		}
-		key = key[:kl]
-		y.Check2(b.keyBuf.Read(key))
-		bf.Add(key)
-	}
-
 	b.finishBlock() // This will never start a new block.
-	index := b.blockIndex()
-	b.buf.Write(index)
+	b.buf = append(b.buf, u32SliceToBytes(b.blockEndOffsets)...)
+	b.buf = append(b.buf, b.baseKeysBuf...)
+	b.buf = append(b.buf, u32SliceToBytes(b.baseKeysEndOffs)...)
+	b.buf = append(b.buf, u32ToBytes(uint32(len(b.baseKeysEndOffs)))...)
 
 	// Write bloom filter.
-	bdata := bf.BinaryMarshal()
-	n, err := b.buf.Write(bdata)
-	y.Check(err)
-	var buf [4]byte
-	binary.BigEndian.PutUint32(buf[:], uint32(n))
-	b.buf.Write(buf[:])
+	bfData := b.bloomFilter.BinaryMarshal()
+	b.buf = append(b.buf, bfData...)
+	b.buf = append(b.buf, u32ToBytes(uint32(len(bfData)))...)
+	return b.buf
+}
 
-	return b.buf.Bytes()
+func u32ToBytes(v uint32) []byte {
+	var uBuf [4]byte
+	binary.LittleEndian.PutUint32(uBuf[:], v)
+	return uBuf[:]
+}
+
+func u32SliceToBytes(u32s []uint32) []byte {
+	var b []byte
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	hdr.Len = len(u32s) * 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&u32s[0]))
+	return b
+}
+
+func bytesToU32Slice(b []byte) []uint32 {
+	var u32s []uint32
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u32s))
+	hdr.Len = len(b) / 4
+	hdr.Cap = hdr.Len
+	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
+	return u32s
 }

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -18,7 +18,6 @@ package table
 
 import (
 	"bytes"
-	"encoding/binary"
 	"io"
 	"sort"
 
@@ -59,7 +58,7 @@ func (itr *blockIterator) Error() error {
 func (itr *blockIterator) loadEntryEndOffsets() {
 	// Get the number of entries from the end of `data` (and remove it).
 	off := len(itr.data) - 4
-	entriesNum := int(binary.LittleEndian.Uint32(itr.data[off:]))
+	entriesNum := int(bytesToU32(itr.data[off:]))
 	itr.data = itr.data[:off]
 	off = len(itr.data) - entriesNum*4
 	itr.entryEndOffsets = bytesToU32Slice(itr.data[off:])

--- a/table/table.go
+++ b/table/table.go
@@ -17,7 +17,6 @@
 package table
 
 import (
-	"encoding/binary"
 	"fmt"
 	"os"
 	"path"
@@ -190,14 +189,14 @@ func (t *Table) readIndex() {
 	// Read bloom filter.
 	readPos -= 4
 	buf := t.readNoFail(readPos, 4)
-	bloomLen := int(binary.LittleEndian.Uint32(buf))
+	bloomLen := int(bytesToU32(buf))
 	readPos -= bloomLen
 	data := t.readNoFail(readPos, bloomLen)
 	t.bf.BinaryUnmarshal(data)
 
 	readPos -= 4
 	buf = t.readNoFail(readPos, 4)
-	numBlocks := int(binary.LittleEndian.Uint32(buf))
+	numBlocks := int(bytesToU32(buf))
 
 	readPos -= 4 * numBlocks
 	buf = t.readNoFail(readPos, 4*numBlocks)

--- a/table/table.go
+++ b/table/table.go
@@ -35,12 +35,6 @@ import (
 
 const fileSuffix = ".sst"
 
-type keyOffset struct {
-	key    []byte
-	offset int
-	len    int
-}
-
 // Table represents a loaded table file with the info we have about it
 type Table struct {
 	sync.Mutex
@@ -48,8 +42,11 @@ type Table struct {
 	fd        *os.File // Own fd.
 	tableSize int      // Initialized in OpenTable, using fd.Stat().
 
-	blockIndex []keyOffset
-	ref        int32 // For file garbage collection.  Atomic.
+	blockEndOffsets []uint32
+	baseKeys        []byte
+	baseKeysEndOffs []uint32
+
+	ref int32 // For file garbage collection.  Atomic.
 
 	loadingMode options.FileLoadingMode
 	mmap        []byte // Memory mapped.
@@ -139,9 +136,7 @@ func OpenTable(fd *os.File, loadingMode options.FileLoadingMode) (*Table, error)
 		}
 	}
 
-	if err := t.readIndex(); err != nil {
-		return nil, y.Wrap(err)
-	}
+	t.readIndex()
 
 	it := t.NewIterator(false)
 	defer it.Close()
@@ -189,111 +184,49 @@ func (t *Table) readNoFail(off int, sz int) []byte {
 	return res
 }
 
-func (t *Table) readIndex() error {
+func (t *Table) readIndex() {
 	readPos := t.tableSize
 
 	// Read bloom filter.
 	readPos -= 4
 	buf := t.readNoFail(readPos, 4)
-	bloomLen := int(binary.BigEndian.Uint32(buf))
+	bloomLen := int(binary.LittleEndian.Uint32(buf))
 	readPos -= bloomLen
 	data := t.readNoFail(readPos, bloomLen)
 	t.bf.BinaryUnmarshal(data)
 
 	readPos -= 4
 	buf = t.readNoFail(readPos, 4)
-	restartsLen := int(binary.BigEndian.Uint32(buf))
+	numBlocks := int(binary.LittleEndian.Uint32(buf))
 
-	readPos -= 4 * restartsLen
-	buf = t.readNoFail(readPos, 4*restartsLen)
+	readPos -= 4 * numBlocks
+	buf = t.readNoFail(readPos, 4*numBlocks)
+	t.baseKeysEndOffs = bytesToU32Slice(buf)
 
-	offsets := make([]int, restartsLen)
-	for i := 0; i < restartsLen; i++ {
-		offsets[i] = int(binary.BigEndian.Uint32(buf[:4]))
-		buf = buf[4:]
-	}
+	baseKeyBufLen := int(t.baseKeysEndOffs[numBlocks-1])
+	readPos -= baseKeyBufLen
+	t.baseKeys = t.readNoFail(readPos, baseKeyBufLen)
 
-	// The last offset stores the end of the last block.
-	for i := 0; i < len(offsets); i++ {
-		var o int
-		if i == 0 {
-			o = 0
-		} else {
-			o = offsets[i-1]
-		}
-
-		ko := keyOffset{
-			offset: o,
-			len:    offsets[i] - o,
-		}
-		t.blockIndex = append(t.blockIndex, ko)
-	}
-
-	che := make(chan error, len(t.blockIndex))
-	blocks := make(chan int, len(t.blockIndex))
-
-	for i := 0; i < len(t.blockIndex); i++ {
-		blocks <- i
-	}
-
-	for i := 0; i < 64; i++ { // Run 64 goroutines.
-		go func() {
-			var h header
-
-			for index := range blocks {
-				ko := &t.blockIndex[index]
-
-				offset := ko.offset
-				buf, err := t.read(offset, h.Size())
-				if err != nil {
-					che <- errors.Wrap(err, "While reading first header in block")
-					continue
-				}
-
-				h.Decode(buf)
-				y.AssertTruef(h.plen == 0, "Key offset: %+v, h.plen = %d", *ko, h.plen)
-
-				offset += h.Size()
-				buf = make([]byte, h.klen)
-				var out []byte
-				if out, err = t.read(offset, int(h.klen)); err != nil {
-					che <- errors.Wrap(err, "While reading first key in block")
-					continue
-				}
-				y.AssertTrue(len(buf) == copy(buf, out))
-
-				ko.key = buf
-				che <- nil
-			}
-		}()
-	}
-	close(blocks) // to stop reading goroutines
-
-	var readError error
-	for i := 0; i < len(t.blockIndex); i++ {
-		if err := <-che; err != nil && readError == nil {
-			readError = err
-		}
-	}
-	if readError != nil {
-		return readError
-	}
-
-	return nil
+	readPos -= 4 * numBlocks
+	buf = t.readNoFail(readPos, 4*numBlocks)
+	t.blockEndOffsets = bytesToU32Slice(buf)
 }
 
 func (t *Table) block(idx int) (block, error) {
-	y.AssertTruef(idx >= 0, "idx=%d", idx)
-	if idx >= len(t.blockIndex) {
+	y.AssertTrue(idx >= 0)
+	if idx >= len(t.blockEndOffsets) {
 		return block{}, errors.New("block out of index")
 	}
-
-	ko := t.blockIndex[idx]
+	var startOffset int
+	if idx > 0 {
+		startOffset = int(t.blockEndOffsets[idx-1])
+	}
+	endOffset := int(t.blockEndOffsets[idx])
 	blk := block{
-		offset: ko.offset,
+		offset: startOffset,
 	}
 	var err error
-	blk.data, err = t.read(blk.offset, ko.len)
+	blk.data, err = t.read(startOffset, endOffset-startOffset)
 	return blk, err
 }
 

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -45,7 +45,7 @@ func buildTestTable(t *testing.T, prefix string, n int) *os.File {
 
 // keyValues is n by 2 where n is number of pairs.
 func buildTable(t *testing.T, keyValues [][]string) *os.File {
-	b := NewTableBuilder()
+	b := NewTableBuilder(0)
 	defer b.Close()
 	// TODO: Add test for file garbage collection here. No files should be left after the tests here.
 
@@ -625,7 +625,7 @@ func TestMergingIteratorTakeTwo(t *testing.T) {
 
 func BenchmarkRead(b *testing.B) {
 	n := 5 << 20
-	builder := NewTableBuilder()
+	builder := NewTableBuilder(0)
 	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
 	f, err := y.OpenSyncedFile(filename, true)
 	y.Check(err)
@@ -655,7 +655,7 @@ func BenchmarkRead(b *testing.B) {
 
 func BenchmarkReadAndBuild(b *testing.B) {
 	n := 5 << 20
-	builder := NewTableBuilder()
+	builder := NewTableBuilder(0)
 	filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
 	f, err := y.OpenSyncedFile(filename, true)
 	y.Check(err)
@@ -675,7 +675,7 @@ func BenchmarkReadAndBuild(b *testing.B) {
 	// Iterate b.N times over the entire table.
 	for i := 0; i < b.N; i++ {
 		func() {
-			newBuilder := NewTableBuilder()
+			newBuilder := NewTableBuilder(0)
 			it := tbl.NewIterator(false)
 			defer it.Close()
 			for it.seekToFirst(); it.Valid(); it.next() {
@@ -695,7 +695,7 @@ func BenchmarkReadMerged(b *testing.B) {
 	var tables []*Table
 	for i := 0; i < m; i++ {
 		filename := fmt.Sprintf("%s%s%d.sst", os.TempDir(), string(os.PathSeparator), rand.Int63())
-		builder := NewTableBuilder()
+		builder := NewTableBuilder(0)
 		f, err := y.OpenSyncedFile(filename, true)
 		y.Check(err)
 		for j := 0; j < tableSize; j++ {

--- a/value.go
+++ b/value.go
@@ -36,7 +36,6 @@ import (
 	"time"
 
 	"github.com/coocood/badger/options"
-
 	"github.com/coocood/badger/y"
 	"github.com/pkg/errors"
 	"golang.org/x/net/trace"

--- a/y/iterator.go
+++ b/y/iterator.go
@@ -55,10 +55,11 @@ func (v *ValueStruct) Encode(b []byte) {
 // EncodeTo should be kept in sync with the Encode function above. The reason
 // this function exists is to avoid creating byte arrays per key-value pair in
 // table/builder.go.
-func (v *ValueStruct) EncodeTo(buf *bytes.Buffer) {
-	buf.WriteByte(v.Meta)
-	buf.WriteByte(v.UserMeta)
-	buf.Write(v.Value)
+func (v *ValueStruct) EncodeTo(buf []byte) []byte {
+	buf = append(buf, v.Meta)
+	buf = append(buf, v.UserMeta)
+	buf = append(buf, v.Value...)
+	return buf
 }
 
 // Iterator is an interface for a basic iterator.


### PR DESCRIPTION
1. store block base keys together at the end of a table, avoid heavy random I/O during loading, speed up loading time.
2. refactor blockIterator to utilize the entry index and simplify code.
3. replace *bytes.Buffer with []byte, and set initial capacity.
4. unsafely convert []uint32 to []byte to avoid memory allocation.
5. add keys to bloom filter directly to avoid memory copy.
6. replace some AssertTruef to AssertTrue.