### PR TITLE
optimize merge iterator

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -253,7 +253,7 @@ var DefaultIteratorOptions = IteratorOptions{
 
 // Iterator helps iterating over the KV pairs in a lexicographically sorted order.
 type Iterator struct {
-	iitr   *y.MergeIterator
+	iitr   y.Iterator
 	txn    *Txn
 	readTs uint64
 


### PR DESCRIPTION
The microbenchmark shows that the new merge iterator improved the performance

from
`20694 ns/op`
to
`8509   ns/op`
on merging 2 chilren iterators.

from
`176898 ns/op` 
to 
`134595 ns/op` 
on merging 8 children iterators.