### PR TITLE
optimize MergeIterator

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -452,8 +452,9 @@ func (it *Iterator) fill(item *Item) {
 	item.meta = vs.Meta
 	item.userMeta = vs.UserMeta
 
-	item.version = y.ParseTs(it.iitr.Key())
-	item.key = y.SafeCopy(item.key, y.ParseKey(it.iitr.Key()))
+	key := it.iitr.Key()
+	item.version = y.ParseTs(key)
+	item.key = y.SafeCopy(item.key, y.ParseKey(key))
 
 	item.vptr = y.SafeCopy(item.vptr, vs.Value)
 	item.val = nil


### PR DESCRIPTION
Iterate over 2 million sysbench keys, 1 million row and 1 million indices.

Before: 600ms

After: 420ms

Iterate writeCF in RocksDB takes 320ms.

So still 30% slower than RocksDB, but much better.