### PR TITLE
Add block hash index to sst file

### DIFF
--- a/level_handler.go
+++ b/level_handler.go
@@ -271,10 +271,18 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 			continue
 		}
 
-		it := th.NewIterator(false)
-		defer it.Close()
+		it, ok := th.PointGet(key)
+		if !ok {
+			it = th.NewIterator(false)
+			defer it.Close()
+			it.Seek(key)
+		} else {
+			if it == nil {
+				continue
+			}
+			defer it.Close()
+		}
 
-		it.Seek(key)
 		if !it.Valid() {
 			continue
 		}

--- a/level_handler.go
+++ b/level_handler.go
@@ -274,14 +274,11 @@ func (s *levelHandler) get(key []byte) (y.ValueStruct, error) {
 		it, ok := th.PointGet(key)
 		if !ok {
 			it = th.NewIterator(false)
-			defer it.Close()
 			it.Seek(key)
-		} else {
-			if it == nil {
-				continue
-			}
-			defer it.Close()
+		} else if it == nil {
+			continue
 		}
+		defer it.Close()
 
 		if !it.Valid() {
 			continue

--- a/levels.go
+++ b/levels.go
@@ -18,6 +18,7 @@ package badger
 
 import (
 	"fmt"
+	"github.com/coocood/badger/options"
 	"math"
 	"math/rand"
 	"os"
@@ -40,7 +41,7 @@ type levelsController struct {
 
 	cstatus compactStatus
 
-	opt TableBuilderOptions
+	opt options.TableBuilderOptions
 }
 
 var (
@@ -73,12 +74,12 @@ func revertToManifest(kv *DB, mf *Manifest, idMap map[uint64]struct{}) error {
 	return nil
 }
 
-func newLevelsController(kv *DB, mf *Manifest, opt TableBuilderOptions) (*levelsController, error) {
+func newLevelsController(kv *DB, mf *Manifest, opt options.TableBuilderOptions) (*levelsController, error) {
 	y.Assert(kv.opt.NumLevelZeroTablesStall > kv.opt.NumLevelZeroTables)
 	s := &levelsController{
 		kv:     kv,
 		levels: make([]*levelHandler, kv.opt.MaxLevels),
-		opt:   opt,
+		opt:    opt,
 	}
 	s.cstatus.levels = make([]*levelCompactStatus, kv.opt.MaxLevels)
 

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -120,7 +120,7 @@ func buildTestTable(t *testing.T, prefix string, n int) *os.File {
 // TODO - Move these to somewhere where table package can also use it.
 // keyValues is n by 2 where n is number of pairs.
 func buildTable(t *testing.T, keyValues [][]string) *os.File {
-	b := table.NewTableBuilder(0)
+	b := table.NewTableBuilder(0, options.TableBuilderOptions{})
 	defer b.Close()
 	// TODO: Add test for file garbage collection here. No files should be left after the tests here.
 
@@ -180,7 +180,7 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 	}
 
 	manifest := createManifest()
-	lc, err := newLevelsController(kv, &manifest)
+	lc, err := newLevelsController(kv, &manifest, options.TableBuilderOptions{})
 	require.NoError(t, err)
 	done = lc.fillTablesL0(&cd)
 	require.Equal(t, true, done)

--- a/options.go
+++ b/options.go
@@ -102,6 +102,8 @@ type Options struct {
 
 	// Truncate value log to delete corrupt data, if any. Would not truncate if ReadOnly is set.
 	Truncate bool
+
+	TableBuilderOptions options.TableBuilderOptions
 }
 
 // DefaultOptions sets a list of recommended options for good performance.
@@ -126,6 +128,10 @@ var DefaultOptions = Options{
 	ValueLogMaxEntries:      1000000,
 	ValueThreshold:          32,
 	Truncate:                false,
+	TableBuilderOptions: options.TableBuilderOptions{
+		EnableHashIndex: false,
+		HashUtilRatio:   0.75,
+	},
 }
 
 // LSMOnlyOptions follows from DefaultOptions, but sets a higher ValueThreshold so values would

--- a/options/options.go
+++ b/options/options.go
@@ -28,3 +28,8 @@ const (
 	// MemoryMap indicates that that the file must be memory-mapped
 	MemoryMap
 )
+
+type TableBuilderOptions struct {
+	EnableHashIndex bool
+	HashUtilRatio   float32
+}

--- a/table/builder.go
+++ b/table/builder.go
@@ -151,7 +151,7 @@ func (b *Builder) finishBlock() {
 }
 
 // Add adds a key-value pair to the block.
-// If doNotRestart is true, we will not blockIdx even if b.counter >= restartInterval.
+// If doNotRestart is true, we will not restart even if b.counter >= restartInterval.
 func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 	if b.counter >= restartInterval {
 		b.finishBlock()

--- a/table/builder.go
+++ b/table/builder.go
@@ -151,7 +151,7 @@ func (b *Builder) finishBlock() {
 }
 
 // Add adds a key-value pair to the block.
-// If doNotRestart is true, we will not restart even if b.counter >= restartInterval.
+// If doNotRestart is true, we will not blockIdx even if b.counter >= restartInterval.
 func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 	if b.counter >= restartInterval {
 		b.finishBlock()

--- a/table/builder.go
+++ b/table/builder.go
@@ -204,18 +204,6 @@ func u32SliceToBytes(u32s []uint32) []byte {
 	return b
 }
 
-func u16SliceToBytes(u16s []uint16) []byte {
-	if len(u16s) == 0 {
-		return nil
-	}
-	var b []byte
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	hdr.Len = len(u16s) * 2
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&u16s[0]))
-	return b
-}
-
 func bytesToU32Slice(b []byte) []uint32 {
 	if len(b) == 0 {
 		return nil
@@ -223,18 +211,6 @@ func bytesToU32Slice(b []byte) []uint32 {
 	var u32s []uint32
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u32s))
 	hdr.Len = len(b) / 4
-	hdr.Cap = hdr.Len
-	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
-	return u32s
-}
-
-func bytesToU16Slice(b []byte) []uint16 {
-	if len(b) == 0 {
-		return nil
-	}
-	var u32s []uint16
-	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&u32s))
-	hdr.Len = len(b) / 2
 	hdr.Cap = hdr.Len
 	hdr.Data = uintptr(unsafe.Pointer(&b[0]))
 	return u32s

--- a/table/builder.go
+++ b/table/builder.go
@@ -153,7 +153,7 @@ func (b *Builder) finishBlock() {
 // Add adds a key-value pair to the block.
 // If doNotRestart is true, we will not restart even if b.counter >= restartInterval.
 func (b *Builder) Add(key []byte, value y.ValueStruct) error {
-	if b.counter > restartInterval {
+	if b.counter >= restartInterval {
 		b.finishBlock()
 	}
 	b.addHelper(key, value)

--- a/table/hash_index.go
+++ b/table/hash_index.go
@@ -1,0 +1,87 @@
+package table
+
+import (
+	"encoding/binary"
+	"github.com/dgryski/go-farm"
+)
+
+const (
+	hashUtilRatio  = 0.75
+	resultNoEntry  = 65535
+	resultFallback = 65534
+	maxRestart     = 65533
+)
+
+type hashIndexBuilder struct {
+	pos []struct {
+		hash    uint32
+		restart uint16
+		offset  uint8
+	}
+	estimatedNumBuckets float32
+	invalid             bool
+}
+
+func (b *hashIndexBuilder) addKey(key []byte, restart uint32, offset uint8) {
+	if restart > maxRestart || b.invalid {
+		b.invalid = true
+		return
+	}
+	b.estimatedNumBuckets += 1 / hashUtilRatio
+	h := farm.Fingerprint32(key)
+	b.pos = append(b.pos, struct {
+		hash    uint32
+		restart uint16
+		offset  uint8
+	}{h, uint16(restart), offset})
+}
+
+func (b *hashIndexBuilder) finish(buf []byte) []byte {
+	if b.invalid || len(b.pos) == 0 {
+		return append(buf, u32ToBytes(0)...)
+	}
+	numBucket := uint32(b.estimatedNumBuckets)
+	buckets := make([]uint32, numBucket)
+	for i := range buckets {
+		buckets[i] = resultNoEntry << 8
+	}
+
+	for _, pair := range b.pos {
+		idx := pair.hash % numBucket
+		restart := buckets[idx] >> 8
+		if restart == resultNoEntry {
+			buckets[idx] = uint32(pair.restart)<<8 | uint32(pair.offset)
+		} else if restart != uint32(pair.restart) {
+			buckets[idx] = uint32(resultFallback) << 8
+		}
+	}
+
+	encodeBuf := [2]byte{}
+	for _, e := range buckets {
+		binary.LittleEndian.PutUint16(encodeBuf[:], uint16(e>>8))
+		buf = append(buf, encodeBuf[:]...)
+		buf = append(buf, byte(e&0xff))
+	}
+	return append(buf, u32ToBytes(numBucket)...)
+}
+
+type hashIndex struct {
+	buckets    []byte
+	numBuckets int
+}
+
+func (i *hashIndex) readIndex(buf []byte, numBucket int) {
+	i.buckets = buf
+	i.numBuckets = numBucket
+}
+
+func (i *hashIndex) lookup(key []byte) (uint32, uint8) {
+	if i.buckets == nil {
+		return resultFallback, 0
+	}
+	h := farm.Fingerprint32(key)
+	idx := int(h) % i.numBuckets
+	buf := i.buckets[idx*3:]
+	restart := binary.LittleEndian.Uint16(buf)
+	return uint32(restart), uint8(buf[2])
+}

--- a/table/hash_index.go
+++ b/table/hash_index.go
@@ -12,13 +12,15 @@ const (
 )
 
 type hashIndexBuilder struct {
-	buf []struct {
-		hash    uint32
-		restart uint16
-		offset  uint8
-	}
+	entries       []indexEntry
 	hashUtilRatio float32
 	invalid       bool
+}
+
+type indexEntry struct {
+	hash    uint32
+	restart uint16
+	offset  uint8
 }
 
 func newHashIndexBuilder(hashUtilRatio float32) hashIndexBuilder {
@@ -28,25 +30,21 @@ func newHashIndexBuilder(hashUtilRatio float32) hashIndexBuilder {
 }
 
 func (b *hashIndexBuilder) addKey(key []byte, restart uint32, offset uint8) {
-	if restart > maxRestart || b.invalid {
+	if restart > maxRestart {
 		b.invalid = true
-		b.buf = nil
+		b.entries = nil
 		return
 	}
 	h := farm.Fingerprint32(key)
-	b.buf = append(b.buf, struct {
-		hash    uint32
-		restart uint16
-		offset  uint8
-	}{h, uint16(restart), offset})
+	b.entries = append(b.entries, indexEntry{h, uint16(restart), offset})
 }
 
 func (b *hashIndexBuilder) finish(buf []byte) []byte {
-	if b.invalid || len(b.buf) == 0 {
+	if b.invalid || len(b.entries) == 0 {
 		return append(buf, u32ToBytes(0)...)
 	}
 
-	numBuckets := uint32(float32(len(b.buf)) / b.hashUtilRatio)
+	numBuckets := uint32(float32(len(b.entries)) / b.hashUtilRatio)
 	bufLen := len(buf)
 	buf = append(buf, make([]byte, numBuckets*3+4)...)
 	buckets := buf[bufLen:]
@@ -54,7 +52,7 @@ func (b *hashIndexBuilder) finish(buf []byte) []byte {
 		binary.LittleEndian.PutUint16(buckets[i*3:], resultNoEntry)
 	}
 
-	for _, h := range b.buf {
+	for _, h := range b.entries {
 		idx := h.hash % numBuckets
 		bucket := buckets[idx*3 : (idx+1)*3]
 		restart := binary.LittleEndian.Uint16(bucket[:2])

--- a/table/hash_index.go
+++ b/table/hash_index.go
@@ -8,7 +8,7 @@ import (
 const (
 	resultNoEntry  = 65535
 	resultFallback = 65534
-	maxRestart     = 65533
+	maxBlockCnt    = 65533
 )
 
 type hashIndexBuilder struct {
@@ -34,7 +34,7 @@ func newHashIndexBuilder(hashUtilRatio float32) hashIndexBuilder {
 }
 
 func (b *hashIndexBuilder) addKey(key []byte, blkIdx uint32, offset uint8) {
-	if blkIdx > maxRestart {
+	if blkIdx > maxBlockCnt {
 		b.invalid = true
 		b.entries = nil
 		return

--- a/table/hash_index.go
+++ b/table/hash_index.go
@@ -20,10 +20,10 @@ type hashIndexBuilder struct {
 type indexEntry struct {
 	hash uint32
 
-	// restart is the index of block (aka restart) which contains this key.
-	restart uint16
+	// blockIdx is the index of block which contains this key.
+	blockIdx uint16
 
-	// offset is the index of this key in block (aka restart).
+	// offset is the index of this key in block.
 	offset uint8
 }
 
@@ -33,14 +33,14 @@ func newHashIndexBuilder(hashUtilRatio float32) hashIndexBuilder {
 	}
 }
 
-func (b *hashIndexBuilder) addKey(key []byte, restart uint32, offset uint8) {
-	if restart > maxRestart {
+func (b *hashIndexBuilder) addKey(key []byte, blkIdx uint32, offset uint8) {
+	if blkIdx > maxRestart {
 		b.invalid = true
 		b.entries = nil
 		return
 	}
 	h := farm.Fingerprint32(key)
-	b.entries = append(b.entries, indexEntry{h, uint16(restart), offset})
+	b.entries = append(b.entries, indexEntry{h, uint16(blkIdx), offset})
 }
 
 func (b *hashIndexBuilder) finish(buf []byte) []byte {
@@ -59,11 +59,11 @@ func (b *hashIndexBuilder) finish(buf []byte) []byte {
 	for _, h := range b.entries {
 		idx := h.hash % numBuckets
 		bucket := buckets[idx*3 : (idx+1)*3]
-		restart := binary.LittleEndian.Uint16(bucket[:2])
-		if restart == resultNoEntry {
-			binary.LittleEndian.PutUint16(bucket[:2], h.restart)
+		blkIdx := binary.LittleEndian.Uint16(bucket[:2])
+		if blkIdx == resultNoEntry {
+			binary.LittleEndian.PutUint16(bucket[:2], h.blockIdx)
 			bucket[2] = h.offset
-		} else if restart != h.restart {
+		} else if blkIdx != h.blockIdx {
 			binary.LittleEndian.PutUint16(bucket[:2], resultFallback)
 		}
 	}
@@ -89,6 +89,6 @@ func (i *hashIndex) lookup(key []byte) (uint32, uint8) {
 	h := farm.Fingerprint32(key)
 	idx := int(h) % i.numBuckets
 	buf := i.buckets[idx*3:]
-	restart := binary.LittleEndian.Uint16(buf)
-	return uint32(restart), uint8(buf[2])
+	blkIdx := binary.LittleEndian.Uint16(buf)
+	return uint32(blkIdx), uint8(buf[2])
 }

--- a/table/hash_index.go
+++ b/table/hash_index.go
@@ -18,9 +18,13 @@ type hashIndexBuilder struct {
 }
 
 type indexEntry struct {
-	hash    uint32
+	hash uint32
+
+	// restart is the index of block (aka restart) which contains this key.
 	restart uint16
-	offset  uint8
+
+	// offset is the index of this key in block (aka restart).
+	offset uint8
 }
 
 func newHashIndexBuilder(hashUtilRatio float32) hashIndexBuilder {

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -209,8 +209,6 @@ func (itr *Iterator) seekHelper(blockIdx int, key []byte) {
 	itr.err = itr.bi.Error()
 }
 
-const seekBound = 3
-
 func (itr *Iterator) seekFromOffset(blockIdx int, offset int, key []byte) {
 	itr.bpos = blockIdx
 	block, err := itr.t.block(blockIdx)
@@ -219,12 +217,9 @@ func (itr *Iterator) seekFromOffset(blockIdx int, offset int, key []byte) {
 		return
 	}
 	itr.bi.setBlock(block)
-	for i := 0; i < seekBound; i++ {
-		itr.bi.setIdx(offset)
-		if y.CompareKeys(itr.bi.key, key) >= 0 {
-			return
-		}
-		offset++
+	itr.bi.setIdx(offset)
+	if y.CompareKeys(itr.bi.key, key) >= 0 {
+		return
 	}
 	itr.bi.seek(key, offset)
 }

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -69,6 +69,7 @@ func (itr *blockIterator) loadEntryEndOffsets() {
 }
 
 // Seek brings us to the first block element that is >= input key.
+// The binary search will begin at `start`, you can use it to skip some items.
 func (itr *blockIterator) seek(key []byte, start int) {
 	foundEntryIdx := sort.Search(len(itr.entryEndOffsets)-start, func(idx int) bool {
 		itr.setIdx(idx + start)

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -70,12 +70,12 @@ func (itr *blockIterator) loadEntryEndOffsets() {
 
 // Seek brings us to the first block element that is >= input key.
 // The binary search will begin at `start`, you can use it to skip some items.
-func (itr *blockIterator) seek(key []byte, start int) {
-	foundEntryIdx := sort.Search(len(itr.entryEndOffsets)-start, func(idx int) bool {
-		itr.setIdx(idx + start)
+func (itr *blockIterator) seek(key []byte) {
+	foundEntryIdx := sort.Search(len(itr.entryEndOffsets), func(idx int) bool {
+		itr.setIdx(idx)
 		return y.CompareKeys(itr.key, key) >= 0
 	})
-	itr.setIdx(foundEntryIdx + start)
+	itr.setIdx(foundEntryIdx)
 }
 
 // seekToFirst brings us to the first element. Valid should return true.
@@ -148,6 +148,10 @@ func (t *Table) NewIterator(reversed bool) *Iterator {
 	return ti
 }
 
+func (t *Table) NewIteratorNoRef(reversed bool) *Iterator {
+	return &Iterator{t: t, reversed: reversed}
+}
+
 // Close closes the iterator (and it must be called).
 func (itr *Iterator) Close() error {
 	return itr.t.DecrRef()
@@ -205,7 +209,7 @@ func (itr *Iterator) seekHelper(blockIdx int, key []byte) {
 		return
 	}
 	itr.bi.setBlock(block)
-	itr.bi.seek(key, 0)
+	itr.bi.seek(key)
 	itr.err = itr.bi.Error()
 }
 
@@ -221,7 +225,7 @@ func (itr *Iterator) seekFromOffset(blockIdx int, offset int, key []byte) {
 	if y.CompareKeys(itr.bi.key, key) >= 0 {
 		return
 	}
-	itr.bi.seek(key, offset)
+	itr.bi.seek(key)
 }
 
 // seekFrom brings us to a key that is >= input key.

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -208,7 +208,9 @@ func (itr *Iterator) seekHelper(blockIdx int, key []byte) {
 	itr.err = itr.bi.Error()
 }
 
-func (itr *Iterator) seekWithStart(blockIdx int, start int, key []byte) {
+const seekBound = 3
+
+func (itr *Iterator) seekFromOffset(blockIdx int, offset int, key []byte) {
 	itr.bpos = blockIdx
 	block, err := itr.t.block(blockIdx)
 	if err != nil {
@@ -216,15 +218,14 @@ func (itr *Iterator) seekWithStart(blockIdx int, start int, key []byte) {
 		return
 	}
 	itr.bi.setBlock(block)
-	numNext := 3
-	for i := 0; i < numNext; i++ {
-		itr.bi.setIdx(start)
+	for i := 0; i < seekBound; i++ {
+		itr.bi.setIdx(offset)
 		if y.CompareKeys(itr.bi.key, key) >= 0 {
 			return
 		}
-		start++
+		offset++
 	}
-	itr.bi.seek(key, start)
+	itr.bi.seek(key, offset)
 }
 
 // seekFrom brings us to a key that is >= input key.

--- a/table/table.go
+++ b/table/table.go
@@ -164,6 +164,14 @@ func (t *Table) Close() error {
 	return t.fd.Close()
 }
 
+// PointGet try to lookup a key by using table's hash index.
+// If it find an hash collision the second return value will be false,
+// which means caller should fallback to seek search. Otherwise the value will be true.
+// If The hash index does not contain such an element, the returned iterator will be nil.
+// Otherwise, the returned iterator is already pointing to the appropriate position.
+// Note: it is possible a non-existing key has a hash conflict with the key in the index.
+// In this case, the returned iterator is not nil and points to an incorrect position.
+// The caller needs to further check if the key is equal.
 func (t *Table) PointGet(key []byte) (*Iterator, bool) {
 	keyNoTS := y.ParseKey(key)
 	blkIdx, offset := t.hIdx.lookup(keyNoTS)

--- a/table/table.go
+++ b/table/table.go
@@ -164,15 +164,10 @@ func (t *Table) Close() error {
 	return t.fd.Close()
 }
 
-// PointGet try to lookup a key by using table's hash index.
-// If it find an hash collision the second return value will be false,
-// which means caller should fallback to seek search. Otherwise the value will be true.
-// If The hash index does not contain such an element, the returned iterator will be nil.
-// Otherwise, the returned iterator is already pointing to the appropriate position.
-//
-// Note: it is possible a non-existing key has a hash conflict with the key in the index.
-// In this case, the returned iterator is not nil and points to an incorrect position.
-// The caller needs to further check if the key is equal.
+// PointGet try to lookup a key and its value by table's hash index.
+// If it find an hash collision the last return value will be false,
+// which means caller should fallback to seek search. Otherwise it value will be true.
+// If the hash index does not contain such an element the returned key will be nil.
 func (t *Table) PointGet(key []byte) ([]byte, y.ValueStruct, bool) {
 	keyNoTS := y.ParseKey(key)
 	blkIdx, offset := t.hIdx.lookup(keyNoTS)

--- a/table/table.go
+++ b/table/table.go
@@ -55,6 +55,8 @@ type Table struct {
 	id                uint64 // file id, part of filename
 
 	bf bbloom.Bloom
+
+	hIdx hashIndex
 }
 
 // IncrRef increments the refcount (having to do with whether the file should be deleted)
@@ -162,6 +164,21 @@ func (t *Table) Close() error {
 	return t.fd.Close()
 }
 
+func (t *Table) PointGet(key []byte) (*Iterator, bool) {
+	keyNoTS := y.ParseKey(key)
+	blkIdx, offset := t.hIdx.lookup(keyNoTS)
+	if blkIdx == resultFallback {
+		return nil, false
+	}
+	if blkIdx == resultNoEntry {
+		return nil, true
+	}
+
+	it := t.NewIterator(false)
+	it.seekWithStart(int(blkIdx), int(offset), key)
+	return it, true
+}
+
 func (t *Table) read(off int, sz int) ([]byte, error) {
 	if len(t.mmap) > 0 {
 		if len(t.mmap[off:]) < sz {
@@ -186,9 +203,19 @@ func (t *Table) readNoFail(off int, sz int) []byte {
 func (t *Table) readIndex() {
 	readPos := t.tableSize
 
-	// Read bloom filter.
 	readPos -= 4
 	buf := t.readNoFail(readPos, 4)
+	numBuckets := int(bytesToU32(buf))
+	if numBuckets != 0 {
+		hashLen := numBuckets * 3
+		readPos -= hashLen
+		buckets := t.readNoFail(readPos, hashLen)
+		t.hIdx.readIndex(buckets, numBuckets)
+	}
+
+	// Read bloom filter.
+	readPos -= 4
+	buf = t.readNoFail(readPos, 4)
 	bloomLen := int(bytesToU32(buf))
 	readPos -= bloomLen
 	data := t.readNoFail(readPos, bloomLen)

--- a/table/table.go
+++ b/table/table.go
@@ -175,7 +175,7 @@ func (t *Table) PointGet(key []byte) (*Iterator, bool) {
 	}
 
 	it := t.NewIterator(false)
-	it.seekWithStart(int(blkIdx), int(offset), key)
+	it.seekFromOffset(int(blkIdx), int(offset), key)
 	return it, true
 }
 


### PR DESCRIPTION
Likes [RocksDB's block hash index](https://rocksdb.org/blog/2018/08/23/data-block-hash-index.html). Can improve point get performance.

Result of BenchmarkPointGet

## ratio 0.5
~~BenchmarkPointGet/Seek-12                  10000           2890639 ns/op
BenchmarkPointGet/Hash-12                  10000           2142101 ns/op~~

## ratio 0.75
~~BenchmarkPointGet/Seek-12                  10000           2839140 ns/op
BenchmarkPointGet/Hash-12                  10000           2316540 ns/op~~

## ratio 1.00
~~BenchmarkPointGet/Seek-12                  10000           2856267 ns/op
BenchmarkPointGet/Hash-12                  10000           2529225 ns/op~~