### PR TITLE
introduce a safe and faster codec of header

### DIFF
--- a/table/builder.go
+++ b/table/builder.go
@@ -35,13 +35,17 @@ type header struct {
 // Encode encodes the header.
 func (h header) Encode() []byte {
 	var b [4]byte
-	*(*header)(unsafe.Pointer(&b[0])) = h
+	b[1] = byte(h.baseLen >> 8)
+	b[0] = byte(h.baseLen & 0xff)
+	b[3] = byte(h.diffLen >> 8)
+	b[2] = byte(h.diffLen & 0xff)
 	return b[:]
 }
 
 // Decode decodes the header.
 func (h *header) Decode(buf []byte) {
-	*h = *(*header)(unsafe.Pointer(&buf[0]))
+	h.baseLen = uint16(buf[1])<<8 | uint16(buf[0])
+	h.diffLen = uint16(buf[3])<<8 | uint16(buf[2])
 }
 
 const headerSize = 4

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -653,6 +653,26 @@ func BenchmarkRead(b *testing.B) {
 	}
 }
 
+func BenchmarkDecode(b *testing.B) {
+	h := header{}
+	buf := h.Encode()
+	var d header
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		d.Decode(buf)
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	h := header{}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Encode()
+	}
+}
+
 func BenchmarkReadAndBuild(b *testing.B) {
 	n := 5 << 20
 	builder := NewTableBuilder(0)


### PR DESCRIPTION
The new Decode method is twice faster than the old unsafe implementation.

BenchmarkDecode-12               2000000000             0.26 ns/op
BenchmarkUnsafeDecode-12         2000000000             0.50 ns/op