### PR TITLE
use fsync instead of O_SYNC when write table

### DIFF
--- a/db.go
+++ b/db.go
@@ -636,7 +636,7 @@ func writeToFile(f *os.File, buf []byte) error {
 			return err
 		}
 	}
-	return nil
+	return f.Sync()
 }
 
 type flushTask struct {
@@ -667,7 +667,7 @@ func (db *DB) flushMemtable(lc *y.Closer) error {
 		}
 
 		fileID := db.lc.reserveFileID()
-		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), true)
+		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), false)
 		if err != nil {
 			return y.Wrap(err)
 		}

--- a/levels.go
+++ b/levels.go
@@ -396,7 +396,7 @@ func (s *levelsController) compactBuildTables(
 			go func(builder *table.Builder) {
 				defer builder.Close()
 
-				fd, err := y.CreateSyncedFile(table.NewFilename(fileID, s.kv.opt.Dir), true)
+				fd, err := y.CreateSyncedFile(table.NewFilename(fileID, s.kv.opt.Dir), false)
 				if err != nil {
 					resultCh <- newTableResult{nil, errors.Wrapf(err, "While opening new table: %d", fileID)}
 					return


### PR DESCRIPTION
Sync file before `writeToFile` return, instead of sync with every `write` syscall.

After this patch, `LOG Compact` time decreased from 15+ seconds to around 1-5 seconds.