### PR TITLE
refactor io related part in table builder

### DIFF
--- a/db.go
+++ b/db.go
@@ -18,7 +18,7 @@ package badger
 
 import (
 	"expvar"
-	"github.com/coocood/badger/options"
+	"golang.org/x/time/rate"
 	"math"
 	"os"
 	"path/filepath"
@@ -73,6 +73,8 @@ type DB struct {
 	memTableCh chan *skl.Skiplist
 
 	orc *oracle
+
+	limiter *rate.Limiter
 }
 
 const (
@@ -253,6 +255,11 @@ func Open(opt Options) (db *DB, err error) {
 		orc:           orc,
 	}
 
+	rateLimit := opt.TableBuilderOptions.BytesPerSecond
+	if rateLimit > 0 {
+		db.limiter = rate.NewLimiter(rate.Limit(rateLimit), rateLimit)
+	}
+
 	go func() {
 		for {
 			db.memTableCh <- skl.NewSkiplist(arenaSize(db.opt))
@@ -388,7 +395,7 @@ func (db *DB) Close() (err error) {
 		nextLevel: db.lc.levels[1],
 	}
 	if db.lc.fillTablesL0(&cd) {
-		if err := db.lc.runCompactDef(0, cd); err != nil {
+		if err := db.lc.runCompactDef(0, cd, nil); err != nil {
 			log.Infof("\tLOG Compact FAILED with error: %+v: %+v", err, cd)
 		}
 	} else {
@@ -611,33 +618,17 @@ func arenaSize(opt Options) int64 {
 }
 
 // WriteLevel0Table flushes memtable. It drops deleteValues.
-func writeLevel0Table(s *skl.Skiplist, f *os.File, opt options.TableBuilderOptions) error {
+func (db *DB) writeLevel0Table(s *skl.Skiplist, f *os.File) error {
 	iter := s.NewIterator()
 	defer iter.Close()
-	b := table.NewTableBuilder(s.MemSize(), opt)
+	b := table.NewTableBuilder(f, db.limiter, db.opt.TableBuilderOptions)
 	defer b.Close()
 	for iter.SeekToFirst(); iter.Valid(); iter.Next() {
 		if err := b.Add(iter.Key(), iter.Value()); err != nil {
 			return err
 		}
 	}
-	return writeToFile(f, b.Finish())
-}
-
-func writeToFile(f *os.File, buf []byte) error {
-	const step = 512 * 1024
-	up := step
-	for base := 0; base < len(buf); base += step {
-		up = base + step
-		if up >= len(buf) {
-			up = len(buf)
-		}
-		_, err := f.Write(buf[base:up])
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return b.Finish()
 }
 
 type flushTask struct {
@@ -668,7 +659,7 @@ func (db *DB) flushMemtable(lc *y.Closer) error {
 		}
 
 		fileID := db.lc.reserveFileID()
-		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), true)
+		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, db.opt.Dir), false)
 		if err != nil {
 			return y.Wrap(err)
 		}
@@ -677,7 +668,7 @@ func (db *DB) flushMemtable(lc *y.Closer) error {
 		dirSyncCh := make(chan error)
 		go func() { dirSyncCh <- syncDir(db.opt.Dir) }()
 
-		err = writeLevel0Table(ft.mt, fd, db.opt.TableBuilderOptions)
+		err = db.writeLevel0Table(ft.mt, fd)
 		dirSyncErr := <-dirSyncCh
 
 		if err != nil {

--- a/fileutil/file_writer.go
+++ b/fileutil/file_writer.go
@@ -1,0 +1,145 @@
+package fileutil
+
+import (
+	"context"
+	"golang.org/x/time/rate"
+	"os"
+)
+
+type BufferedFileWriter struct {
+	f              *os.File
+	buf            []byte
+	fileSize       int64
+	bufSize        int64
+	bytesPerSync   int64
+	lastSyncOffset int64
+
+	limiter *rate.Limiter
+}
+
+func NewBufferedFileWriter(f *os.File, bufSize int, bytesPerSync int, limiter *rate.Limiter) *BufferedFileWriter {
+	return &BufferedFileWriter{
+		f:            f,
+		buf:          make([]byte, 0, bufSize),
+		bufSize:      int64(bufSize),
+		bytesPerSync: int64(bytesPerSync),
+		limiter:      limiter,
+	}
+}
+
+func (bw *BufferedFileWriter) Append(data []byte) error {
+	return bw.appendData(data, true)
+}
+
+func (bw *BufferedFileWriter) Flush(fsync bool) error {
+	if err := bw.flushBuffer(!fsync); err != nil {
+		return err
+	}
+	if fsync {
+		return bw.fdatasync()
+	}
+	return nil
+}
+
+func (bw *BufferedFileWriter) FlushWithData(data []byte, fsync bool) error {
+	if err := bw.appendData(data, !fsync); err != nil {
+		return err
+	}
+	if err := bw.flushBuffer(!fsync); err != nil {
+		return err
+	}
+	if fsync {
+		return bw.fdatasync()
+	}
+	return nil
+}
+
+func (bw *BufferedFileWriter) Reset(f *os.File) {
+	bw.f = f
+	bw.buf = bw.buf[:0]
+	bw.fileSize = 0
+	bw.lastSyncOffset = 0
+}
+
+func (bw *BufferedFileWriter) ResetWithLimiter(f *os.File, limiter *rate.Limiter) {
+	bw.Reset(f)
+	bw.limiter = limiter
+}
+
+func (bw *BufferedFileWriter) write(data []byte, syncRange bool) error {
+	for cur := 0; cur < len(data); {
+		allowed := bw.requestTokenForWrite(len(data) - cur)
+		if _, err := bw.f.Write(data[cur : cur+allowed]); err != nil {
+			return err
+		}
+		bw.fileSize += int64(allowed)
+		if syncRange {
+			if err := bw.trySyncFileRange(); err != nil {
+				return err
+			}
+		}
+		cur += allowed
+	}
+	return nil
+}
+
+func (bw *BufferedFileWriter) flushBuffer(syncRange bool) error {
+	if len(bw.buf) == 0 {
+		return nil
+	}
+	if err := bw.write(bw.buf, syncRange); err != nil {
+		return err
+	}
+	bw.buf = bw.buf[:0]
+	return nil
+}
+
+func (bw *BufferedFileWriter) appendData(data []byte, syncRange bool) error {
+	if cap(bw.buf)-len(bw.buf) < len(data) && len(bw.buf) > 0 {
+		if err := bw.flushBuffer(syncRange); err != nil {
+			return err
+		}
+	}
+	if cap(bw.buf) >= len(data) {
+		bw.buf = append(bw.buf, data...)
+		return nil
+	}
+	return bw.write(data, syncRange)
+}
+
+func (bw *BufferedFileWriter) trySyncFileRange() error {
+	var err error
+	const bytesAlign = 4 * 1024
+	const bytesNotSync = 1024 * 1024
+	if bw.bytesPerSync != 0 && bw.fileSize > bytesNotSync {
+		// We try to avoid sync the last 1mb of data. For two reasons:
+		// 1. avoid rewrite the same page that is modified later.
+		// 2. write may block while writing out the page in some OS.
+		syncOffset := bw.fileSize - bytesNotSync
+		syncOffset -= syncOffset % bytesAlign
+		syncSize := syncOffset - bw.lastSyncOffset
+		if syncOffset > 0 && syncSize >= bw.bytesPerSync {
+			err = SyncFileRange(bw.f, bw.lastSyncOffset, syncSize, true)
+			bw.lastSyncOffset = syncOffset
+		}
+	}
+	return err
+}
+
+func (bw *BufferedFileWriter) fdatasync() error {
+	bw.lastSyncOffset = bw.fileSize
+	return Fdatasync(bw.f)
+}
+
+func (bw *BufferedFileWriter) requestTokenForWrite(size int) int {
+	if bw.limiter == nil {
+		return size
+	}
+
+	n, max := size, bw.limiter.Burst()
+	if max != 0 && size > max {
+		n = max
+	}
+	bw.limiter.WaitN(context.Background(), n)
+	return n
+}

--- a/fileutil/preallocate.go
+++ b/fileutil/preallocate.go
@@ -1,0 +1,14 @@
+package fileutil
+
+import "os"
+
+func Preallocate(f *os.File, size int64) error {
+	if size == 0 {
+		return nil
+	}
+	return preallocate(f, size)
+}
+
+func preallocateTrunc(f *os.File, size int64) error {
+	return f.Truncate(size)
+}

--- a/fileutil/preallocate_linux.go
+++ b/fileutil/preallocate_linux.go
@@ -1,0 +1,19 @@
+// +build linux
+
+package fileutil
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func preallocate(f *os.File, size int64) error {
+	err := unix.Fallocate(int(f.Fd()), 0, 0, size)
+	if err != nil {
+		errno, ok := err.(unix.Errno)
+		if ok && (errno == unix.ENOTSUP || errno == unix.EINTR) {
+			return preallocateTrunc(f, size)
+		}
+	}
+	return err
+}

--- a/fileutil/preallocate_others.go
+++ b/fileutil/preallocate_others.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package fileutil
+
+import "os"
+
+func preallocate(f *os.File, size int64) error {
+	return preallocateTrunc(f, size)
+}

--- a/fileutil/sync.go
+++ b/fileutil/sync.go
@@ -1,0 +1,20 @@
+// +build !linux,!darwin
+
+package fileutil
+
+import "os"
+
+// Fsync is a wrapper around file.Sync(). Special handling is needed on darwin platform.
+func Fsync(f *os.File) error {
+	return f.Sync()
+}
+
+// Fdatasync is a wrapper around file.Sync(). Special handling is needed on linux platform.
+func Fdatasync(f *os.File) error {
+	return f.Sync()
+}
+
+// SyncFileRange does nothing on non linux platform.
+func SyncFileRange(f *os.File, offset int64, size int64, async bool) error {
+	return nil
+}

--- a/fileutil/sync_darwin.go
+++ b/fileutil/sync_darwin.go
@@ -1,0 +1,28 @@
+// +build darwin
+
+package fileutil
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// Fsync on HFS/OSX flushes the data on to the physical drive but the drive
+// may not write it to the persistent media for quite sometime and it may be
+// written in out-of-order sequence. Using F_FULLFSYNC ensures that the
+// physical drive's buffer will also get flushed to the media.
+func Fsync(f *os.File) error {
+	_, err := unix.FcntlInt(f.Fd(), unix.F_FULLFSYNC, 0)
+	return err
+}
+
+// Fdatasync on darwin platform invokes fcntl(F_FULLFSYNC) for actual persistence
+// on physical drive media.
+func Fdatasync(f *os.File) error {
+	return Fsync(f)
+}
+
+// SyncFileRange does nothing on non linux platform.
+func SyncFileRange(f *os.File, offset int64, size int64, async bool) error {
+	return nil
+}

--- a/fileutil/sync_linux.go
+++ b/fileutil/sync_linux.go
@@ -1,0 +1,41 @@
+// +build linux
+
+package fileutil
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+// Fsync is a wrapper around file.Sync(). Special handling is needed on darwin platform.
+func Fsync(f *os.File) error {
+	return f.Sync()
+}
+
+// Fdatasync is similar to fsync(), but does not flush modified metadata
+// unless that metadata is needed in order to allow a subsequent data retrieval
+// to be correctly handled.
+func Fdatasync(f *os.File) error {
+	return unix.Fdatasync(int(f.Fd()))
+}
+
+// SyncFileRange use sync_file_range() to flush dirty pages.
+// offset is the starting byte of the file range to be synchronized;
+// nbytes specifies the length of the range to be synchronized, in bytes.
+// If nbytes is zero, then all bytes from offset through to the end of file are synchronized.
+// Synchronization is in units of the system page size:
+// offset is rounded down to a page boundary; (offset+nbytes-1) is rounded up to a page boundary.
+// If async is true, just initiate write-out of all dirty pages in the specified range
+// which are not presently submitted write-out. Note that even this may block
+// if you attempt to write more than request queue size.
+// Otherwise it will wait upon write-out of all pages in the range after performing any write.
+//
+// Important: unlike Fdatasync, this function will never update file's metadata (size etc.), which means there are no
+// guarantees that the data will be available after a crash. Please use Fsync or Fdatasync at the end of file write.
+func SyncFileRange(f *os.File, offset int64, nbytes int64, async bool) error {
+	flag := unix.SYNC_FILE_RANGE_WRITE
+	if !async {
+		flag |= unix.SYNC_FILE_RANGE_WAIT_AFTER
+	}
+	return unix.SyncFileRange(int(f.Fd()), offset, nbytes, flag)
+}

--- a/levels.go
+++ b/levels.go
@@ -19,6 +19,7 @@ package badger
 import (
 	"fmt"
 	"github.com/coocood/badger/options"
+	"golang.org/x/time/rate"
 	"math"
 	"math/rand"
 	"os"
@@ -289,14 +290,8 @@ func (ds *DiscardStats) collect(vs y.ValueStruct) {
 	ds.numSkips++
 }
 
-type newTableResult struct {
-	table *table.Table
-	err   error
-}
-
 // compactBuildTables merge topTables and botTables to form a list of new tables.
-func (s *levelsController) compactBuildTables(
-	level int, cd compactDef) ([]*table.Table, func() error, error) {
+func (s *levelsController) compactBuildTables(level int, cd compactDef, limiter *rate.Limiter) ([]*table.Table, func() error, error) {
 	topTables := cd.top
 	botTables := cd.bot
 
@@ -328,13 +323,26 @@ func (s *levelsController) compactBuildTables(
 	// would affect the snapshot view guarantee provided by transactions.
 	minReadTs := s.kv.orc.readMark.MinReadTs()
 
-	// Start generating new tables.
-	resultCh := make(chan newTableResult)
-	var numBuilds, numVersions int
+	var numVersions int
 	var lastKey, skipKey []byte
+	var newTables []*table.Table
+	var firstErr error
+	var builder *table.Builder
+
 	for it.Valid() {
 		timeStart := time.Now()
-		builder := table.NewTableBuilder(s.kv.opt.MaxTableSize, s.opt)
+		fileID := s.reserveFileID()
+		fd, err := y.CreateSyncedFile(table.NewFilename(fileID, s.kv.opt.Dir), false)
+		if err != nil {
+			firstErr = err
+			break
+		}
+		if builder == nil {
+			builder = table.NewTableBuilder(fd, limiter, s.opt)
+		} else {
+			builder.ResetWithLimiter(fd, limiter)
+		}
+
 		var numKeys uint64
 		for ; it.Valid(); it.Next() {
 			// See if we need to skip this key.
@@ -394,39 +402,16 @@ func (s *levelsController) compactBuildTables(
 		// called Add() at least once, and builder is not Empty().
 		log.Infof("Added %d keys. Skipped %d keys.", numKeys, discardStats.numSkips)
 		log.Infof("LOG Compact. Iteration took: %v\n", time.Since(timeStart))
-		if !builder.Empty() {
-			numBuilds++
-			fileID := s.reserveFileID()
-			go func(builder *table.Builder) {
-				defer builder.Close()
-
-				fd, err := y.CreateSyncedFile(table.NewFilename(fileID, s.kv.opt.Dir), true)
-				if err != nil {
-					resultCh <- newTableResult{nil, errors.Wrapf(err, "While opening new table: %d", fileID)}
-					return
-				}
-
-				if err := writeToFile(fd, builder.Finish()); err != nil {
-					resultCh <- newTableResult{nil, errors.Wrapf(err, "Unable to write to file: %d", fileID)}
-					return
-				}
-
-				tbl, err := table.OpenTable(fd, s.kv.opt.TableLoadingMode)
-				// decrRef is added below.
-				resultCh <- newTableResult{tbl, errors.Wrapf(err, "Unable to open table: %q", fd.Name())}
-			}(builder)
+		if err := builder.Finish(); err != nil {
+			firstErr = err
+			break
 		}
-	}
-
-	newTables := make([]*table.Table, 0, numBuilds)
-	// Wait for all table builders to finish.
-	var firstErr error
-	for x := 0; x < numBuilds; x++ {
-		res := <-resultCh
-		newTables = append(newTables, res.table)
-		if firstErr == nil {
-			firstErr = res.err
+		tbl, err := table.OpenTable(fd, s.kv.opt.TableLoadingMode)
+		if err != nil {
+			firstErr = err
+			break
 		}
+		newTables = append(newTables, tbl)
 	}
 
 	if firstErr == nil {
@@ -439,10 +424,8 @@ func (s *levelsController) compactBuildTables(
 	if firstErr != nil {
 		// An error happened.  Delete all the newly created table files (by calling DecrRef
 		// -- we're the only holders of a ref).
-		for j := 0; j < numBuilds; j++ {
-			if newTables[j] != nil {
-				newTables[j].DecrRef()
-			}
+		for _, tbl := range newTables {
+			tbl.DecrRef()
 		}
 		errorReturn := errors.Wrapf(firstErr, "While running compaction for: %+v", cd)
 		return nil, nil, errorReturn
@@ -577,7 +560,7 @@ func (s *levelsController) fillTables(cd *compactDef) bool {
 	return false
 }
 
-func (s *levelsController) runCompactDef(l int, cd compactDef) (err error) {
+func (s *levelsController) runCompactDef(l int, cd compactDef, limiter *rate.Limiter) (err error) {
 	timeStart := time.Now()
 
 	thisLevel := cd.thisLevel
@@ -586,7 +569,7 @@ func (s *levelsController) runCompactDef(l int, cd compactDef) (err error) {
 	// Table should never be moved directly between levels, always be rewritten to allow discarding
 	// invalid versions.
 
-	newTables, decr, err := s.compactBuildTables(l, cd)
+	newTables, decr, err := s.compactBuildTables(l, cd, limiter)
 	if err != nil {
 		return err
 	}
@@ -649,7 +632,7 @@ func (s *levelsController) doCompact(p compactionPriority) (bool, error) {
 	defer s.cstatus.delete(cd) // Remove the ranges from compaction status.
 
 	log.Infof("Running for level: %d\n", cd.thisLevel.level)
-	if err := s.runCompactDef(l, cd); err != nil {
+	if err := s.runCompactDef(l, cd, s.kv.limiter); err != nil {
 		// This compaction couldn't be done successfully.
 		log.Infof("\tLOG Compact FAILED with error: %+v: %+v", err, cd)
 		return false, err

--- a/options.go
+++ b/options.go
@@ -104,6 +104,8 @@ type Options struct {
 	Truncate bool
 
 	TableBuilderOptions options.TableBuilderOptions
+
+	ValueLogWriteOptions options.ValueLogWriterOptions
 }
 
 // DefaultOptions sets a list of recommended options for good performance.
@@ -131,6 +133,13 @@ var DefaultOptions = Options{
 	TableBuilderOptions: options.TableBuilderOptions{
 		EnableHashIndex: false,
 		HashUtilRatio:   0.75,
+		WriteBufferSize: 1 * 1024 * 1024,
+		BytesPerSync:    0,
+		BytesPerSecond:  -1,
+	},
+	ValueLogWriteOptions: options.ValueLogWriterOptions{
+		WriteBufferSize: 2 * 1024 * 1024,
+		BytesPerSync:    0,
 	},
 }
 

--- a/options/options.go
+++ b/options/options.go
@@ -32,4 +32,12 @@ const (
 type TableBuilderOptions struct {
 	EnableHashIndex bool
 	HashUtilRatio   float32
+	WriteBufferSize int
+	BytesPerSync    int
+	BytesPerSecond  int
+}
+
+type ValueLogWriterOptions struct {
+	WriteBufferSize int
+	BytesPerSync    int
 }

--- a/structs.go
+++ b/structs.go
@@ -56,7 +56,8 @@ type header struct {
 }
 
 const (
-	headerBufSize = 10
+	headerBufSize       = 10
+	metaNotEntryEncoded = 0
 )
 
 func (h header) Encode(out []byte) {
@@ -74,6 +75,13 @@ func (h *header) Decode(buf []byte) {
 	h.klen = binary.BigEndian.Uint32(buf[1:5])
 	h.vlen = binary.BigEndian.Uint32(buf[5:9])
 	h.umlen = buf[9]
+}
+
+func isEncodedHeader(data []byte) bool {
+	if len(data) < 1 {
+		return false
+	}
+	return data[0] != metaNotEntryEncoded
 }
 
 // Entry provides Key, Value, UserMeta. This struct can be used by the user to set data.

--- a/structs.go
+++ b/structs.go
@@ -61,6 +61,7 @@ const (
 
 func (h header) Encode(out []byte) {
 	y.Assert(len(out) >= headerBufSize)
+	// Because meta can never be 0xff, so 0x00 in vlog file indicates there is not an entry.
 	out[0] = ^h.meta
 	binary.BigEndian.PutUint32(out[1:5], h.klen)
 	binary.BigEndian.PutUint32(out[5:9], h.vlen)

--- a/structs.go
+++ b/structs.go
@@ -61,17 +61,17 @@ const (
 
 func (h header) Encode(out []byte) {
 	y.Assert(len(out) >= headerBufSize)
-	binary.BigEndian.PutUint32(out[0:4], h.klen)
-	binary.BigEndian.PutUint32(out[4:8], h.vlen)
-	out[8] = h.meta
+	out[0] = ^h.meta
+	binary.BigEndian.PutUint32(out[1:5], h.klen)
+	binary.BigEndian.PutUint32(out[5:9], h.vlen)
 	out[9] = h.umlen
 }
 
 // Decodes h from buf.
 func (h *header) Decode(buf []byte) {
-	h.klen = binary.BigEndian.Uint32(buf[0:4])
-	h.vlen = binary.BigEndian.Uint32(buf[4:8])
-	h.meta = buf[8]
+	h.meta = ^buf[0]
+	h.klen = binary.BigEndian.Uint32(buf[1:5])
+	h.vlen = binary.BigEndian.Uint32(buf[5:9])
 	h.umlen = buf[9]
 }
 
@@ -123,7 +123,7 @@ func encodeEntry(e *Entry, buf *bytes.Buffer) (int, error) {
 	binary.BigEndian.PutUint32(crcBuf[:], hash.Sum32())
 	buf.Write(crcBuf[:])
 
-	return len(headerEnc) + len(e.Key) + len(e.Value) + len(crcBuf), nil
+	return len(headerEnc) + len(e.UserMeta) + len(e.Key) + len(e.Value) + len(crcBuf), nil
 }
 
 func (e Entry) print(prefix string) {

--- a/table/builder.go
+++ b/table/builder.go
@@ -77,7 +77,7 @@ type Builder struct {
 }
 
 // NewTableBuilder makes a new TableBuilder.
-// The initCap is used to avoid memory reallocation.
+// If the limiter is nil, the write speed during table build will not be limited.
 func NewTableBuilder(f *os.File, limiter *rate.Limiter, opt options.TableBuilderOptions) *Builder {
 	assumeKeyNum := 256 * 1024
 	return &Builder{
@@ -91,11 +91,13 @@ func NewTableBuilder(f *os.File, limiter *rate.Limiter, opt options.TableBuilder
 	}
 }
 
+// Reset this builder with new file.
 func (b *Builder) Reset(f *os.File) {
 	b.resetBuffers()
 	b.w.Reset(f)
 }
 
+// Reset this builder with new file and rate limiter.
 func (b *Builder) ResetWithLimiter(f *os.File, limiter *rate.Limiter) {
 	b.resetBuffers()
 	b.w.ResetWithLimiter(f, limiter)
@@ -211,7 +213,7 @@ func (b *Builder) ReachedCapacity(capacity int64) bool {
 	return int64(estimateSz) > capacity
 }
 
-// Flush finishes the table by appending the index.
+// Finish finishes the table by appending the index.
 func (b *Builder) Finish() error {
 	b.finishBlock() // This will never start a new block.
 	b.buf = append(b.buf, u32SliceToBytes(b.blockEndOffsets)...)

--- a/table/builder.go
+++ b/table/builder.go
@@ -18,7 +18,10 @@ package table
 
 import (
 	"encoding/binary"
+	"github.com/coocood/badger/fileutil"
 	"github.com/coocood/badger/options"
+	"golang.org/x/time/rate"
+	"os"
 	"reflect"
 	"unsafe"
 
@@ -51,8 +54,9 @@ const headerSize = 4
 type Builder struct {
 	counter int // Number of keys written for the current block.
 
-	// Typically tens or hundreds of meg. This is for one single file.
-	buf []byte
+	w          *fileutil.BufferedFileWriter
+	buf        []byte
+	writtenLen int
 
 	baseKeysBuf     []byte
 	baseKeysEndOffs []uint32
@@ -74,10 +78,11 @@ type Builder struct {
 
 // NewTableBuilder makes a new TableBuilder.
 // The initCap is used to avoid memory reallocation.
-func NewTableBuilder(initCap int64, opt options.TableBuilderOptions) *Builder {
+func NewTableBuilder(f *os.File, limiter *rate.Limiter, opt options.TableBuilderOptions) *Builder {
 	assumeKeyNum := 256 * 1024
 	return &Builder{
-		buf:         make([]byte, 0, initCap),
+		w:           fileutil.NewBufferedFileWriter(f, opt.WriteBufferSize, opt.BytesPerSync, limiter),
+		buf:         make([]byte, 0, 4*1024),
 		baseKeysBuf: make([]byte, 0, assumeKeyNum/restartInterval),
 		// assume a large enough num of keys to init bloom filter.
 		bloomFilter:      bbloom.New(float64(assumeKeyNum), 0.01),
@@ -86,11 +91,35 @@ func NewTableBuilder(initCap int64, opt options.TableBuilderOptions) *Builder {
 	}
 }
 
+func (b *Builder) Reset(f *os.File) {
+	b.resetBuffers()
+	b.w.Reset(f)
+}
+
+func (b *Builder) ResetWithLimiter(f *os.File, limiter *rate.Limiter) {
+	b.resetBuffers()
+	b.w.ResetWithLimiter(f, limiter)
+}
+
+func (b *Builder) resetBuffers() {
+	b.counter = 0
+	b.buf = b.buf[:0]
+	b.writtenLen = 0
+	b.baseKeysBuf = b.baseKeysBuf[:0]
+	b.baseKeysEndOffs = b.baseKeysEndOffs[:0]
+	b.blockBaseKey = b.blockBaseKey[:0]
+	b.blockBaseOffset = 0
+	b.blockEndOffsets = b.blockEndOffsets[:0]
+	b.entryEndOffsets = b.entryEndOffsets[:0]
+	b.bloomFilter.Clear()
+	b.hashIndexBuilder.reset()
+}
+
 // Close closes the TableBuilder.
 func (b *Builder) Close() {}
 
 // Empty returns whether it's empty.
-func (b *Builder) Empty() bool { return len(b.buf) == 0 }
+func (b *Builder) Empty() bool { return b.writtenLen+len(b.buf) == 0 }
 
 // keyDiff returns a suffix of newKey that is different from b.blockBaseKey.
 func (b Builder) keyDiff(newKey []byte) []byte {
@@ -130,14 +159,14 @@ func (b *Builder) addHelper(key []byte, v y.ValueStruct) {
 	b.buf = append(b.buf, h.Encode()...)
 	b.buf = append(b.buf, diffKey...) // We only need to store the key difference.
 	b.buf = v.EncodeTo(b.buf)
-	b.entryEndOffsets = append(b.entryEndOffsets, uint32(len(b.buf))-b.blockBaseOffset)
+	b.entryEndOffsets = append(b.entryEndOffsets, uint32(b.writtenLen+len(b.buf))-b.blockBaseOffset)
 	b.counter++ // Increment number of keys added for this current block.
 }
 
-func (b *Builder) finishBlock() {
+func (b *Builder) finishBlock() error {
 	b.buf = append(b.buf, u32SliceToBytes(b.entryEndOffsets)...)
 	b.buf = append(b.buf, u32ToBytes(uint32(len(b.entryEndOffsets)))...)
-	b.blockEndOffsets = append(b.blockEndOffsets, uint32(len(b.buf)))
+	b.blockEndOffsets = append(b.blockEndOffsets, uint32(b.writtenLen+len(b.buf)))
 
 	// Add base key.
 	b.baseKeysBuf = append(b.baseKeysBuf, b.blockBaseKey...)
@@ -147,14 +176,22 @@ func (b *Builder) finishBlock() {
 	b.entryEndOffsets = b.entryEndOffsets[:0]
 	b.counter = 0
 	b.blockBaseKey = b.blockBaseKey[:0]
-	b.blockBaseOffset = uint32(len(b.buf))
+	b.blockBaseOffset = uint32(b.writtenLen + len(b.buf))
+	b.writtenLen += len(b.buf)
+	if err := b.w.Append(b.buf); err != nil {
+		return err
+	}
+	b.buf = b.buf[:0]
+	return nil
 }
 
 // Add adds a key-value pair to the block.
 // If doNotRestart is true, we will not restart even if b.counter >= restartInterval.
 func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 	if b.counter >= restartInterval {
-		b.finishBlock()
+		if err := b.finishBlock(); err != nil {
+			return err
+		}
 	}
 	b.addHelper(key, value)
 	return nil // Currently, there is no meaningful error.
@@ -167,15 +204,15 @@ func (b *Builder) Add(key []byte, value y.ValueStruct) error {
 
 // ReachedCapacity returns true if we... roughly (?) reached capacity?
 func (b *Builder) ReachedCapacity(capacity int64) bool {
-	estimateSz := len(b.buf) +
+	estimateSz := b.writtenLen + len(b.buf) +
 		4*len(b.blockEndOffsets) +
 		len(b.baseKeysBuf) +
 		4*len(b.baseKeysEndOffs)
 	return int64(estimateSz) > capacity
 }
 
-// Finish finishes the table by appending the index.
-func (b *Builder) Finish() []byte {
+// Flush finishes the table by appending the index.
+func (b *Builder) Finish() error {
 	b.finishBlock() // This will never start a new block.
 	b.buf = append(b.buf, u32SliceToBytes(b.blockEndOffsets)...)
 	b.buf = append(b.buf, b.baseKeysBuf...)
@@ -193,7 +230,7 @@ func (b *Builder) Finish() []byte {
 		b.buf = append(b.buf, u32ToBytes(0)...)
 	}
 
-	return b.buf
+	return b.w.FlushWithData(b.buf, true)
 }
 
 func u32ToBytes(v uint32) []byte {

--- a/table/hash_index.go
+++ b/table/hash_index.go
@@ -72,6 +72,11 @@ func (b *hashIndexBuilder) finish(buf []byte) []byte {
 	return buf
 }
 
+func (b *hashIndexBuilder) reset() {
+	b.entries = b.entries[:0]
+	b.invalid = false
+}
+
 type hashIndex struct {
 	buckets    []byte
 	numBuckets int

--- a/value.go
+++ b/value.go
@@ -155,7 +155,7 @@ func (r *safeRead) Entry(reader *bufio.Reader) (*Entry, error) {
 	}
 
 	// Encounter preallocated region, just act as EOF.
-	if hbuf[0] == 0 {
+	if !isEncodedHeader(hbuf[:]) {
 		return nil, io.EOF
 	}
 

--- a/value.go
+++ b/value.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/ngaut/log"
 
+	"github.com/coocood/badger/fileutil"
 	"github.com/coocood/badger/options"
 	"github.com/coocood/badger/y"
 	"github.com/pkg/errors"
@@ -101,7 +102,7 @@ func (lf *logFile) read(p valuePointer, s *y.Slice) (buf []byte, err error) {
 func (lf *logFile) doneWriting(offset uint32) error {
 	// Sync before acquiring lock.  (We call this from write() and thus know we have shared access
 	// to the fd.)
-	if err := lf.fd.Sync(); err != nil {
+	if err := fileutil.Fsync(lf.fd); err != nil {
 		return errors.Wrapf(err, "Unable to sync value log: %q", lf.path)
 	}
 	// Close and reopen the file read-only.  Acquire lock because fd will become invalid for a bit.
@@ -127,7 +128,7 @@ func (lf *logFile) doneWriting(offset uint32) error {
 
 // You must hold lf.lock to sync()
 func (lf *logFile) sync() error {
-	return lf.fd.Sync()
+	return fileutil.Fsync(lf.fd)
 }
 
 var errStop = errors.New("Stop iteration")
@@ -151,6 +152,11 @@ func (r *safeRead) Entry(reader *bufio.Reader) (*Entry, error) {
 	tee := io.TeeReader(reader, hash)
 	if _, err = io.ReadFull(tee, hbuf[:]); err != nil {
 		return nil, err
+	}
+
+	// Encounter preallocated region, just act as EOF.
+	if hbuf[0] == 0 {
+		return nil, io.EOF
 	}
 
 	var h header
@@ -213,10 +219,10 @@ func (r *safeRead) Entry(reader *bufio.Reader) (*Entry, error) {
 
 // iterate iterates over log file. It doesn't not allocate new memory for every kv pair.
 // Therefore, the kv pair is only valid for the duration of fn call.
-func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) error {
+func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) (uint32, error) {
 	_, err := lf.fd.Seek(int64(offset), io.SeekStart)
 	if err != nil {
-		return y.Wrap(err)
+		return 0, y.Wrap(err)
 	}
 
 	reader := bufio.NewReader(lf.fd)
@@ -226,18 +232,16 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) error {
 		recordOffset: offset,
 	}
 
-	truncate := false
 	var lastCommit uint64
-	var validEndOffset uint32
+	validEndOffset := read.recordOffset
 	for {
 		e, err := read.Entry(reader)
 		if err == io.EOF {
 			break
 		} else if err == io.ErrUnexpectedEOF || err == errTruncate {
-			truncate = true
 			break
 		} else if err != nil {
-			return err
+			return validEndOffset, err
 		} else if e == nil {
 			continue
 		}
@@ -255,51 +259,37 @@ func (vlog *valueLog) iterate(lf *logFile, offset uint32, fn logEntry) error {
 				lastCommit = txnTs
 			}
 			if lastCommit != txnTs {
-				truncate = true
 				break
 			}
-
 		} else if e.meta&bitFinTxn > 0 {
 			txnTs, err := strconv.ParseUint(string(e.Value), 10, 64)
 			if err != nil || lastCommit != txnTs {
-				truncate = true
 				break
 			}
 			// Got the end of txn. Now we can store them.
 			lastCommit = 0
 			validEndOffset = read.recordOffset
-
 		} else {
 			if lastCommit != 0 {
 				// This is most likely an entry which was moved as part of GC.
 				// We shouldn't get this entry in the middle of a transaction.
-				truncate = true
 				break
 			}
 			validEndOffset = read.recordOffset
 		}
 
 		if vlog.opt.ReadOnly {
-			return ErrReplayNeeded
+			return validEndOffset, ErrReplayNeeded
 		}
 		if err := fn(*e, vp); err != nil {
 			if err == errStop {
 				break
 			}
-			return y.Wrap(err)
+			return validEndOffset, y.Wrap(err)
 		}
 	}
 
-	if vlog.opt.Truncate && truncate && len(lf.fmap) == 0 {
-		// Only truncate if the file isn't mmaped. Otherwise, Windows would puke.
-		if err := lf.fd.Truncate(int64(validEndOffset)); err != nil {
-			return err
-		}
-	} else if truncate {
-		return ErrTruncateNeeded
-	}
-
-	return nil
+	return validEndOffset, nil
 }
 
 func (vlog *valueLog) rewrite(f *logFile) error {
@@ -371,7 +361,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 		return nil
 	}
 
-	err := vlog.iterate(f, 0, func(e Entry, vp valuePointer) error {
+	_, err := vlog.iterate(f, 0, func(e Entry, vp valuePointer) error {
 		return fe(e)
 	})
 	if err != nil {
@@ -528,8 +518,10 @@ type lfDiscardStats struct {
 }
 
 type valueLog struct {
-	buf     bytes.Buffer
-	dirPath string
+	buf        bytes.Buffer
+	pendingLen int
+	dirPath    string
+	curWriter  *fileutil.BufferedFileWriter
 
 	// guards our view of which files exist, which to be deleted, how many active iterators
 	filesLock        sync.RWMutex
@@ -595,15 +587,14 @@ func (vlog *valueLog) openOrCreateFiles(readOnly bool) error {
 	for fid, lf := range vlog.filesMap {
 		if fid == maxFid {
 			var flags uint32
-			if vlog.opt.SyncWrites {
-				flags |= y.Sync
-			}
 			if readOnly {
 				flags |= y.ReadOnly
 			}
 			if lf.fd, err = y.OpenExistingFile(vlog.fpath(fid), flags); err != nil {
 				return errors.Wrapf(err, "Unable to open value log file")
 			}
+			opt := &vlog.opt.ValueLogWriteOptions
+			vlog.curWriter = fileutil.NewBufferedFileWriter(lf.fd, opt.WriteBufferSize, opt.BytesPerSync, nil)
 		} else {
 			if err := lf.openReadOnly(); err != nil {
 				return err
@@ -629,8 +620,17 @@ func (vlog *valueLog) createVlogFile(fid uint32) (*logFile, error) {
 	vlog.numEntriesWritten = 0
 
 	var err error
-	if lf.fd, err = y.CreateSyncedFile(path, vlog.opt.SyncWrites); err != nil {
+	if lf.fd, err = y.CreateSyncedFile(path, false); err != nil {
 		return nil, errors.Wrapf(err, "Unable to create value log file")
+	}
+	if err = fileutil.Preallocate(lf.fd, vlog.opt.ValueLogFileSize); err != nil {
+		return nil, errors.Wrap(err, "Unable to preallocate value log file")
+	}
+	opt := &vlog.opt.ValueLogWriteOptions
+	if vlog.curWriter == nil {
+		vlog.curWriter = fileutil.NewBufferedFileWriter(lf.fd, opt.WriteBufferSize, opt.BytesPerSync, nil)
+	} else {
+		vlog.curWriter.Reset(lf.fd)
 	}
 
 	if err = syncDir(vlog.dirPath); err != nil {
@@ -658,23 +658,17 @@ func (vlog *valueLog) Open(kv *DB, opt Options) error {
 }
 
 func (vlog *valueLog) Close() error {
-
 	var err error
-	for id, f := range vlog.filesMap {
-
+	for _, f := range vlog.filesMap {
 		f.lock.Lock() // We won’t release the lock.
-		if !vlog.opt.ReadOnly && id == vlog.maxFid {
-			// truncate writable log file to correct offset.
-			if truncErr := f.fd.Truncate(
-				int64(vlog.writableLogOffset)); truncErr != nil && err == nil {
-				err = truncErr
-			}
+		// A successful close does not guarantee that the data has been successfully saved to disk, as the kernel defers writes.
+		// It is not common for a file system to flush the buffers when the stream is closed.
+		if syncErr := fileutil.Fdatasync(f.fd); syncErr != nil {
+			err = syncErr
 		}
-
 		if closeErr := f.fd.Close(); closeErr != nil && err == nil {
 			err = closeErr
 		}
-
 	}
 	return err
 }
@@ -704,7 +698,7 @@ func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 	offset := ptr.Offset + ptr.Len
 
 	fids := vlog.sortedFids()
-
+	var lastOffset uint32
 	for _, id := range fids {
 		if id < fid {
 			continue
@@ -714,16 +708,19 @@ func (vlog *valueLog) Replay(ptr valuePointer, fn logEntry) error {
 			of = 0
 		}
 		f := vlog.filesMap[id]
-		err := vlog.iterate(f, of, fn)
+		endAt, err := vlog.iterate(f, of, fn)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to replay value log: %q", f.path)
+		}
+		if id == vlog.maxFid {
+			lastOffset = endAt
 		}
 	}
 
 	// Seek to the end to start writing.
 	var err error
 	last := vlog.filesMap[vlog.maxFid]
-	lastOffset, err := last.fd.Seek(0, io.SeekEnd)
+	_, err = last.fd.Seek(int64(lastOffset), io.SeekStart)
 	atomic.AddUint32(&vlog.writableLogOffset, uint32(lastOffset))
 	return errors.Wrapf(err, "Unable to seek to end of value log: %q", last.path)
 }
@@ -782,18 +779,17 @@ func (vlog *valueLog) write(reqs []*request) error {
 	vlog.filesLock.RUnlock()
 
 	toDisk := func() error {
-		if vlog.buf.Len() == 0 {
+		if vlog.pendingLen == 0 {
 			return nil
 		}
-		log.Debugf("Flushing %d blocks of total size: %d", len(reqs), vlog.buf.Len())
-		n, err := curlf.fd.Write(vlog.buf.Bytes())
+		err := vlog.curWriter.Flush(vlog.opt.SyncWrites)
 		if err != nil {
 			return errors.Wrapf(err, "Unable to write to value log file: %q", curlf.path)
 		}
 		y.NumWrites.Add(1)
-		y.NumBytesWritten.Add(int64(n))
-		atomic.AddUint32(&vlog.writableLogOffset, uint32(n))
-		vlog.buf.Reset()
+		y.NumBytesWritten.Add(int64(vlog.pendingLen))
+		atomic.AddUint32(&vlog.writableLogOffset, uint32(vlog.pendingLen))
+		vlog.pendingLen = 0
 
 		if vlog.writableOffset() > uint32(vlog.opt.ValueLogFileSize) ||
 			vlog.numEntriesWritten > vlog.opt.ValueLogMaxEntries {
@@ -822,11 +818,14 @@ func (vlog *valueLog) write(reqs []*request) error {
 
 			p.Fid = curlf.fid
 			// Use the offset including buffer length so far.
-			p.Offset = vlog.writableOffset() + uint32(vlog.buf.Len())
+			p.Offset = vlog.writableOffset() + uint32(vlog.pendingLen)
 			plen, err := encodeEntry(e, &vlog.buf) // Now encode the entry into buffer.
 			if err != nil {
 				return err
 			}
+			vlog.curWriter.Append(vlog.buf.Bytes())
+			vlog.buf.Reset()
+			vlog.pendingLen += plen
 			p.Len = uint32(plen)
 			b.Ptrs = append(b.Ptrs, p)
 		}
@@ -834,7 +833,7 @@ func (vlog *valueLog) write(reqs []*request) error {
 		// We write to disk here so that all entries that are part of the same transaction are
 		// written to the same vlog file.
 		writeNow :=
-			vlog.writableOffset()+uint32(vlog.buf.Len()) > uint32(vlog.opt.ValueLogFileSize) ||
+			vlog.writableOffset()+uint32(vlog.pendingLen) > uint32(vlog.opt.ValueLogFileSize) ||
 				vlog.numEntriesWritten > uint32(vlog.opt.ValueLogMaxEntries)
 		if writeNow {
 			if err := toDisk(); err != nil {
@@ -1019,7 +1018,7 @@ func (vlog *valueLog) doRunGC(lf *logFile, discardRatio float64) (err error) {
 	y.Assert(vlog.kv != nil)
 	s := new(y.Slice)
 	var numIterations int
-	err = vlog.iterate(lf, 0, func(e Entry, vp valuePointer) error {
+	_, err = vlog.iterate(lf, 0, func(e Entry, vp valuePointer) error {
 		numIterations++
 		esz := float64(vp.Len) / (1 << 20) // in MBs. +4 for the CAS stuff.
 		if skipped < skipFirstM {


### PR DESCRIPTION
## Motivation
There are some shortcomings in badger’s IO related part.
* Use `O_DSYNC` instead of `fdatasync`, besides some platform define `O_DSYNC` but doesn’t respect to it (fortunately Linux 3.2.0+ works well), this flag also restrict the way we write data to file. Because each `write` call will sync data, so we must keep as much as possible data in buffer instead of let it in system cache.
* Unfortunately, due to badger doesn’t preallocate file with desired size, each `write` will extend file size. In this case, `fdatasync (O_DSYNC)` have to update file’s metadata.
* To control the IO spike, currently we break table flush to small chunks and write them chuck by chunk. But according to previous reason, it cause a lots of metadata update. As final result, the flushing process takes a longer time to finish, occupying online queries’ IO bandwidth for a longer time.

## What Is Changed And How It Works
* Introduce a `buffered file writer` in `vlog writer` and `table builder` . Instead of use `O_DSYNC` when open file, call `fdatasync` at the end of file writing. After this change, `table builder` doesn’t need to allocate a large buffer for each table and start a goroutine to write. It can reuse the `builder` instance, and call `write` while iteration. 
* Preallocating `value log` file. After this change, `fdatasync` can really reduce IO of update metadata.
* To control the IO spike:
	* Using `sync_file_range` to hint OS to flush some dirty pages . Linux has a useful sync function, `sync_file_range`, it can flush specific dirty pages to disk and **never** update metadata. `buffered file writer` use it internally, controlled by `BytesPerSync`. With this change, we can control the total number of dirty pages in cache, avoid a burst IO when call `fdatasync`.
	* Introduce `rate limiter` in `table builder`. `buffered file writer` also support `Token Buckets` rate limiter. We can config the max write speed during compaction, reserve enough IO bandwidth for online queries.
	* Combine the two method, we can control the IO of compaction more reliable than current implementation.
* Introduce a bunch of options to config this new features.

## Benchmark Result Of Sysbench
### Config
```
nodes:
192.168.199.105: pd，sysbench，TiDB
192.168.199.104, 192.168.199.180, 192.168.199.100: TiDB
192.168.199.106: unistore

sysbench:
tables=1 
table-size=10000000
512 connections per TiDB

TiDB:
[prepared-plan-cache]
enabled = true
[txn-local-latches]
enabled = false 

unistore:
table-loading-mode = memory-map
num-mem-tables = 3
num-level-zero-tables = 3
num-index-dbs = 2
num-row-dbs = 2
hash-ratio = 0.75
```

Config of `this branch`
```
TableBuilderOptions.BytesPerSync = 2MB
TableBuilderOptions.WriteBufferSize = 1MB
TableBuilderOptions.BytesPerSecond = 20MB
ValueLogWriteOptions.WriteBufferSize = 8MB
ValueLogWriteOptions.BytesPerSync = 0 # disabled
```
Others config keeps the same with `master`

### update_index
**master**
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           4896925
        other:                           0
        total:                           4896925
    transactions:                        4896925 (8094.49 per sec.)
    queries:                             4896925 (8094.49 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          604.9675s
    total number of events:              4896925

Latency (ms):
         min:                                   61.80
         avg:                                  250.98
         max:                                10358.28
         95th percentile:                      376.49
         sum:                           1229014495.25

Threads fairness:
    events (avg/stddev):           2391.0767/29.39
    execution time (avg/stddev):   600.1047/0.25
```

**this branch**
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           5213163
        other:                           0
        total:                           5213163
    transactions:                        5213163 (8629.19 per sec.)
    queries:                             5213163 (8629.19 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          604.1294s
    total number of events:              5213163

Latency (ms):
         min:                                   60.34
         avg:                                  235.76
         max:                                10831.32
         95th percentile:                      404.61
         sum:                           1229030647.02

Threads fairness:
    events (avg/stddev):           2545.4897/32.64
    execution time (avg/stddev):   600.1126/0.26
```
The `QPS` and `95% late` during table compaction, keeps nearly the same between these two branch.
### update_non_index
**master**
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           8713622
        other:                           0
        total:                           8713622
    transactions:                        8713622 (14516.39 per sec.)
    queries:                             8713622 (14516.39 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          600.2594s
    total number of events:              8713622

Latency (ms):
         min:                                   58.72
         avg:                                  141.03
         max:                                 1461.83
         95th percentile:                      257.95
         sum:                           1228860921.23

Threads fairness:
    events (avg/stddev):           4254.6982/277.47
    execution time (avg/stddev):   600.0297/0.04
```

**this branch**
```
SQL statistics:
    queries performed:
        read:                            0
        write:                           10407699
        other:                           0
        total:                           10407699
    transactions:                        10407699 (17338.18 per sec.)
    queries:                             10407699 (17338.18 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          600.2745s
    total number of events:              10407699

Latency (ms):
         min:                                   51.78
         avg:                                  118.08
         max:                                 1469.13
         95th percentile:                      200.47
         sum:                           1228919206.10

Threads fairness:
    events (avg/stddev):           5081.8843/388.01
    execution time (avg/stddev):   600.0582/0.05
```
The `QPS` during compaction of `this branch` is much higher than `master` (around 12k vs around 8k)
