### PR TITLE
support sub compaction to speed up large compaction

### DIFF
--- a/level_handler.go
+++ b/level_handler.go
@@ -332,11 +332,15 @@ type levelHandlerRLocked struct{}
 // This function should already have acquired a read lock, and this is so important the caller must
 // pass an empty parameter declaring such.
 func (s *levelHandler) overlappingTables(_ levelHandlerRLocked, kr keyRange) (int, int) {
-	left := sort.Search(len(s.tables), func(i int) bool {
-		return y.CompareKeys(kr.left, s.tables[i].Biggest()) <= 0
+	return getTablesInRange(s.tables, kr.left, kr.right)
+}
+
+func getTablesInRange(tbls []*table.Table, start, end []byte) (int, int) {
+	left := sort.Search(len(tbls), func(i int) bool {
+		return y.CompareKeys(start, tbls[i].Biggest()) <= 0
 	})
-	right := sort.Search(len(s.tables), func(i int) bool {
-		return y.CompareKeys(kr.right, s.tables[i].Smallest()) < 0
+	right := sort.Search(len(tbls), func(i int) bool {
+		return y.CompareKeys(end, tbls[i].Smallest()) < 0
 	})
 	return left, right
 }

--- a/levels.go
+++ b/levels.go
@@ -500,9 +500,7 @@ func (cd *compactDef) getInputBounds() []rangeWithSize {
 	for i := 0; i < len(bounds)-1; i++ {
 		start, end := bounds[i], bounds[i+1]
 		sz := cd.sizeInRange(cd.top, cd.thisLevel.level, start, end)
-		if len(cd.bot) != 0 {
-			sz += cd.sizeInRange(cd.bot, cd.nextLevel.level, start, end)
-		}
+		sz += cd.sizeInRange(cd.bot, cd.nextLevel.level, start, end)
 		ranges = append(ranges, rangeWithSize{start: start, end: end, sz: sz})
 	}
 

--- a/levels.go
+++ b/levels.go
@@ -606,6 +606,7 @@ func (s *levelsController) fillTables(cd *compactDef) bool {
 	return false
 }
 
+// determineSubCompactPlan returns the number of sub compactors and the estimated size of each compaction job.
 func (s *levelsController) determineSubCompactPlan(bounds []rangeWithSize) (int, int) {
 	n := s.kv.opt.MaxSubCompaction
 	if len(bounds) < n {
@@ -616,13 +617,11 @@ func (s *levelsController) determineSubCompactPlan(bounds []rangeWithSize) (int,
 	for _, bound := range bounds {
 		size += bound.sz
 	}
-	maxOutPutFiles := int(float32(size) / (4.0 / 5.0) / float32(s.kv.opt.MaxTableSize))
+
+	const minFileFillPercent = 4.0 / 5.0
+	maxOutPutFiles := int(math.Ceil(float64(size) / minFileFillPercent / float64(s.kv.opt.MaxTableSize)))
 	if maxOutPutFiles < n {
 		n = maxOutPutFiles
-	}
-
-	if n == 0 {
-		return 1, size
 	}
 	return n, size / n
 }

--- a/options.go
+++ b/options.go
@@ -83,6 +83,9 @@ type Options struct {
 	// Number of compaction workers to run concurrently.
 	NumCompactors int
 
+	// Max number of sub compaction, set 1 or 0 to disable sub compaction.
+	MaxSubCompaction int
+
 	// Transaction start and commit timestamps are manaVgedTxns by end-user. This
 	// is a private option used by ManagedDB.
 	managedTxns bool
@@ -121,6 +124,7 @@ var DefaultOptions = Options{
 	MaxLevels:               7,
 	MaxTableSize:            64 << 20,
 	NumCompactors:           3,
+	MaxSubCompaction:        3,
 	NumLevelZeroTables:      5,
 	NumLevelZeroTablesStall: 10,
 	NumMemtables:            5,

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -228,12 +228,8 @@ func (itr *Iterator) seekFromOffset(blockIdx int, offset int, key []byte) {
 	itr.bi.seek(key)
 }
 
-// seekFrom brings us to a key that is >= input key.
-func (itr *Iterator) seekFrom(key []byte) {
-	itr.err = nil
-	itr.reset()
-
-	idx := sort.Search(len(itr.t.blockEndOffsets), func(idx int) bool {
+func (itr *Iterator) seekBlock(key []byte) int {
+	return sort.Search(len(itr.t.blockEndOffsets), func(idx int) bool {
 		baseKeyStartOff := 0
 		if idx > 0 {
 			baseKeyStartOff = int(itr.t.baseKeysEndOffs[idx-1])
@@ -242,6 +238,14 @@ func (itr *Iterator) seekFrom(key []byte) {
 		baseKey := itr.t.baseKeys[baseKeyStartOff:baseKeyEndOff]
 		return y.CompareKeys(baseKey, key) > 0
 	})
+}
+
+// seekFrom brings us to a key that is >= input key.
+func (itr *Iterator) seekFrom(key []byte) {
+	itr.err = nil
+	itr.reset()
+
+	idx := itr.seekBlock(key)
 	if idx == 0 {
 		// The smallest key in our table is already strictly > key. We can return that.
 		// This is like a SeekToFirst.

--- a/table/table.go
+++ b/table/table.go
@@ -264,6 +264,25 @@ func (t *Table) block(idx int) (block, error) {
 	return blk, err
 }
 
+func (t *Table) ApproximateSizeInRange(start, end []byte) int {
+	it := t.NewIteratorNoRef(false)
+	startOff, endOff := t.approximateOffset(it, start), t.approximateOffset(it, end)
+	return endOff - startOff
+}
+
+func (t *Table) approximateOffset(it *Iterator, key []byte) int {
+	if y.CompareKeys(t.Biggest(), key) < 0 {
+		return int(t.blockEndOffsets[len(t.blockEndOffsets)-1])
+	} else if y.CompareKeys(t.Smallest(), key) > 0 {
+		return 0
+	}
+	blk := it.seekBlock(key)
+	if blk != 0 {
+		return int(t.blockEndOffsets[blk-1])
+	}
+	return 0
+}
+
 // Size is its file size in bytes
 func (t *Table) Size() int64 { return int64(t.tableSize) }
 


### PR DESCRIPTION
Use sub compaction to avoid write stall due to large L1 to L2 compaction block L0 compaction, and speed up L0 to L1 compaction.