### PR TITLE
fix crash and sync_file_range refine

### DIFF
--- a/fileutil/file_writer.go
+++ b/fileutil/file_writer.go
@@ -83,7 +83,7 @@ func (bw *BufferedFileWriter) write(data []byte, syncRange bool) error {
 		if sz > int(bw.bufSize) {
 			sz = int(bw.bufSize)
 		}
-		allowed := bw.requestTokenForWrite(len(data) - cur)
+		allowed := bw.requestTokenForWrite(sz)
 		if _, err := bw.f.Write(data[cur : cur+allowed]); err != nil {
 			return err
 		}

--- a/fileutil/file_writer.go
+++ b/fileutil/file_writer.go
@@ -134,7 +134,7 @@ func (bw *BufferedFileWriter) trySyncFileRange() error {
 		syncOffset -= syncOffset % bytesAlign
 		syncSize := syncOffset - bw.lastSyncOffset
 		if syncOffset > 0 && syncSize >= bw.bytesPerSync {
-			err = SyncFileRange(bw.f, bw.lastSyncOffset, syncSize, false)
+			err = SyncFileRange(bw.f, bw.lastSyncOffset, syncSize)
 			bw.lastSyncOffset = syncOffset
 		}
 	}

--- a/fileutil/file_writer.go
+++ b/fileutil/file_writer.go
@@ -2,8 +2,9 @@ package fileutil
 
 import (
 	"context"
-	"golang.org/x/time/rate"
 	"os"
+
+	"golang.org/x/time/rate"
 )
 
 type BufferedFileWriter struct {
@@ -78,6 +79,10 @@ func (bw *BufferedFileWriter) ResetWithLimiter(f *os.File, limiter *rate.Limiter
 
 func (bw *BufferedFileWriter) write(data []byte, syncRange bool) error {
 	for cur := 0; cur < len(data); {
+		sz := len(data) - cur
+		if sz > int(bw.bufSize) {
+			sz = int(bw.bufSize)
+		}
 		allowed := bw.requestTokenForWrite(len(data) - cur)
 		if _, err := bw.f.Write(data[cur : cur+allowed]); err != nil {
 			return err
@@ -129,7 +134,7 @@ func (bw *BufferedFileWriter) trySyncFileRange() error {
 		syncOffset -= syncOffset % bytesAlign
 		syncSize := syncOffset - bw.lastSyncOffset
 		if syncOffset > 0 && syncSize >= bw.bytesPerSync {
-			err = SyncFileRange(bw.f, bw.lastSyncOffset, syncSize, true)
+			err = SyncFileRange(bw.f, bw.lastSyncOffset, syncSize, false)
 			bw.lastSyncOffset = syncOffset
 		}
 	}

--- a/fileutil/sync.go
+++ b/fileutil/sync.go
@@ -15,6 +15,6 @@ func Fdatasync(f *os.File) error {
 }
 
 // SyncFileRange does nothing on non linux platform.
-func SyncFileRange(f *os.File, offset int64, size int64, async bool) error {
+func SyncFileRange(f *os.File, offset int64, size int64) error {
 	return nil
 }

--- a/fileutil/sync_darwin.go
+++ b/fileutil/sync_darwin.go
@@ -23,6 +23,6 @@ func Fdatasync(f *os.File) error {
 }
 
 // SyncFileRange does nothing on non linux platform.
-func SyncFileRange(f *os.File, offset int64, size int64, async bool) error {
+func SyncFileRange(f *os.File, offset int64, size int64) error {
 	return nil
 }

--- a/fileutil/sync_linux.go
+++ b/fileutil/sync_linux.go
@@ -33,10 +33,7 @@ func Fdatasync(f *os.File) error {
 //
 // Important: unlike Fdatasync, this function will never update file's metadata (size etc.), which means there are no
 // guarantees that the data will be available after a crash. Please use Fsync or Fdatasync at the end of file write.
-func SyncFileRange(f *os.File, offset int64, nbytes int64, async bool) error {
-	flag := unix.SYNC_FILE_RANGE_WRITE
-	if !async {
-		flag |= unix.SYNC_FILE_RANGE_WAIT_AFTER | unix.SYNC_FILE_RANGE_WAIT_BEFORE
-	}
+func SyncFileRange(f *os.File, offset int64, nbytes int64) error {
+	flag := unix.SYNC_FILE_RANGE_WRITE | unix.SYNC_FILE_RANGE_WAIT_AFTER | unix.SYNC_FILE_RANGE_WAIT_BEFORE
 	return unix.SyncFileRange(int(f.Fd()), offset, nbytes, flag)
 }

--- a/fileutil/sync_linux.go
+++ b/fileutil/sync_linux.go
@@ -3,8 +3,9 @@
 package fileutil
 
 import (
-	"golang.org/x/sys/unix"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 // Fsync is a wrapper around file.Sync(). Special handling is needed on darwin platform.
@@ -35,7 +36,7 @@ func Fdatasync(f *os.File) error {
 func SyncFileRange(f *os.File, offset int64, nbytes int64, async bool) error {
 	flag := unix.SYNC_FILE_RANGE_WRITE
 	if !async {
-		flag |= unix.SYNC_FILE_RANGE_WAIT_AFTER
+		flag |= unix.SYNC_FILE_RANGE_WAIT_AFTER | unix.SYNC_FILE_RANGE_WAIT_BEFORE
 	}
 	return unix.SyncFileRange(int(f.Fd()), offset, nbytes, flag)
 }

--- a/level_handler.go
+++ b/level_handler.go
@@ -95,7 +95,10 @@ func (s *levelHandler) deleteTables(toDel []*table.Table) error {
 	}
 	s.tables = newTables
 
-	assertTablesOrder(newTables)
+	// We can add new L0 tables during compaction, so we shouldn't assert tables order for L0.
+	if s.level != 0 {
+		assertTablesOrder(newTables)
+	}
 
 	s.Unlock() // Unlock s _before_ we DecrRef our tables, which can be slow.
 

--- a/table/mem_table.go
+++ b/table/mem_table.go
@@ -195,7 +195,7 @@ func (it *listNodeIterator) Seek(key []byte) {
 		return y.CompareKeys(it.n.entries[i].Key, key) >= 0
 	})
 	if it.reversed {
-		if !bytes.Equal(it.Key(), key) {
+		if !it.Valid() || !bytes.Equal(it.Key(), key) {
 			it.idx--
 		}
 	}


### PR DESCRIPTION
* let `sync_file_range` block until disk IO done. Let write slow down when the disk is busy.
* fix two crash bugs.