### PR TITLE
remove keyBuf in table iterator

### DIFF
--- a/table/iterator.go
+++ b/table/iterator.go
@@ -30,9 +30,8 @@ type blockIterator struct {
 	err     error
 	baseKey []byte
 
-	key    []byte
-	val    []byte
-	keyBuf [256]byte
+	key []byte
+	val []byte
 
 	keyPrefixLen    uint16
 	entryEndOffsets []uint32
@@ -43,7 +42,7 @@ func (itr *blockIterator) setBlock(b block) {
 	itr.idx = 0
 	itr.baseKey = itr.baseKey[:0]
 	itr.keyPrefixLen = 0
-	itr.key = itr.keyBuf[:0]
+	itr.key = itr.key[:0]
 	itr.val = itr.val[:0]
 	itr.data = b.data
 	itr.loadEntryEndOffsets()


### PR DESCRIPTION
Makes iterator struct smaller, reduce allocation cost.