### PR TITLE
implement FastWaterMark

### DIFF
--- a/db.go
+++ b/db.go
@@ -240,9 +240,8 @@ func Open(opt Options) (db *DB, err error) {
 		isManaged:  opt.managedTxns,
 		nextCommit: 1,
 		commits:    make(map[uint64]uint64),
-		readMark:   y.WaterMark{},
+		readMark:   y.NewFastWaterMark(),
 	}
-	orc.readMark.Init()
 
 	db = &DB{
 		imm:           make([]*table.MemTable, 0, opt.NumMemtables),

--- a/db_test.go
+++ b/db_test.go
@@ -1146,7 +1146,7 @@ func TestMinReadTs(t *testing.T) {
 		}
 		time.Sleep(time.Millisecond)
 		require.Equal(t, uint64(10), db.orc.readTs())
-		min := db.orc.readMark.MinReadTs()
+		min := db.orc.readMark.MinReadTS()
 		require.Equal(t, uint64(9), min)
 
 		readTxn := db.NewTransaction(false)
@@ -1157,10 +1157,14 @@ func TestMinReadTs(t *testing.T) {
 		}
 		require.Equal(t, uint64(20), db.orc.readTs())
 		time.Sleep(time.Millisecond)
-		require.Equal(t, min, db.orc.readMark.MinReadTs())
+		require.Equal(t, min, db.orc.readMark.MinReadTS())
 		readTxn.Discard()
 		time.Sleep(time.Millisecond)
-		require.Equal(t, uint64(19), db.orc.readMark.MinReadTs())
+		require.Equal(t, uint64(10), db.orc.readMark.MinReadTS())
+		// The minReadTS can only be increase by newer txn done.
+		readTxn = db.NewTransaction(false)
+		readTxn.Discard()
+		require.Equal(t, uint64(20), db.orc.readMark.MinReadTS())
 
 		for i := 0; i < 10; i++ {
 			db.View(func(txn *Txn) error {
@@ -1168,7 +1172,7 @@ func TestMinReadTs(t *testing.T) {
 			})
 		}
 		time.Sleep(time.Millisecond)
-		require.Equal(t, uint64(20), db.orc.readMark.MinReadTs())
+		require.Equal(t, uint64(20), db.orc.readMark.MinReadTS())
 	})
 }
 

--- a/levels.go
+++ b/levels.go
@@ -323,7 +323,7 @@ func (lc *levelsController) compactBuildTables(level int, cd compactDef, limiter
 	// Pick up the currently pending transactions' min readTs, so we can discard versions below this
 	// readTs. We should never discard any versions starting from above this timestamp, because that
 	// would affect the snapshot view guarantee provided by transactions.
-	minReadTs := lc.kv.orc.readMark.MinReadTs()
+	minReadTs := lc.kv.orc.readMark.MinReadTS()
 
 	var filter CompactionFilter
 	if lc.kv.opt.CompactionFilterFactory != nil {

--- a/y/wartermark_test.go
+++ b/y/wartermark_test.go
@@ -1,0 +1,55 @@
+package y
+
+import (
+	"sync/atomic"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFastWaterMark(t *testing.T) {
+	fwm := NewFastWaterMark()
+	node := fwm.Begin(100)
+	fwm.Done(node)
+	require.True(t, fwm.MinReadTS() == 100)
+
+	t1 := fwm.Begin(103)
+	t2 := fwm.Begin(102)
+	require.True(t, t2.ReadTS == 103)
+	t3 := fwm.Begin(105)
+	fwm.Done(t2)
+	require.True(t, fwm.MinReadTS() == 100)
+	require.True(t, t2.next == unsafe.Pointer(t1))
+	fwm.Done(t1)
+	require.True(t, fwm.MinReadTS() == 103)
+	fwm.Done(t3)
+	require.True(t, fwm.MinReadTS() == 105)
+	require.True(t, t3.next == nil)
+}
+
+var counter uint64
+
+func BenchmarkFastWaterMark(b *testing.B) {
+	b.ReportAllocs()
+	fwm := NewFastWaterMark()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			node := fwm.Begin(atomic.AddUint64(&counter, 1))
+			fwm.Done(node)
+		}
+	})
+}
+
+func BenchmarkWaterMark(b *testing.B) {
+	b.ReportAllocs()
+	wm := new(WaterMark)
+	wm.Init()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			readTS := atomic.AddUint64(&counter, 1)
+			wm.Begin(readTS)
+			wm.Done(readTS)
+		}
+	})
+}


### PR DESCRIPTION
It makes new transaction much cheaper.

Benchmark result:

BenchmarkFastWaterMark-8   	10000000	       158 ns/op	      32 B/op	       1 allocs/op
BenchmarkWaterMark-8       	 1000000	      1177 ns/op	      16 B/op	       1 allocs/op