### PR TITLE
fix MultiGet bugs

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -167,7 +167,7 @@ func (item *Item) yieldItemValue(dst []byte) ([]byte, error) {
 	// instead.
 	key := y.KeyWithTs(item.Key(), item.Version())
 	moveKey := append(badgerMove, key...)
-	vs := item.db.get(moveKey)
+	vs := item.db.get(moveKey, nil)
 	if vs.Version != item.Version() {
 		return nil, nil
 	}

--- a/levels.go
+++ b/levels.go
@@ -850,14 +850,14 @@ func (s *levelsController) close() error {
 }
 
 // get returns the found value if any. If not found, we return nil.
-func (s *levelsController) get(key []byte) y.ValueStruct {
+func (s *levelsController) get(key []byte, refs RefMap) y.ValueStruct {
 	// It's important that we iterate the levels from 0 on upward.  The reason is, if we iterated
 	// in opposite order, or in parallel (naively calling all the h.RLock() in some order) we could
 	// read level L's tables post-compaction and level L+1's tables pre-compaction.  (If we do
 	// parallelize this, we will need to call the h.RLock() function by increasing order of level
 	// number.)
 	for _, h := range s.levels {
-		vs := h.get(key) // Calls h.RLock() and h.RUnlock().
+		vs := h.get(key, refs) // Calls h.RLock() and h.RUnlock().
 		if vs.Valid() {
 			return vs
 		}
@@ -865,9 +865,9 @@ func (s *levelsController) get(key []byte) y.ValueStruct {
 	return y.ValueStruct{}
 }
 
-func (s *levelsController) multiGet(pairs []keyValuePair) {
+func (s *levelsController) multiGet(pairs []keyValuePair, refs RefMap) {
 	for _, h := range s.levels {
-		h.multiGet(pairs)
+		h.multiGet(pairs, refs)
 	}
 }
 

--- a/value.go
+++ b/value.go
@@ -308,7 +308,7 @@ func (vlog *valueLog) rewrite(f *logFile) error {
 			log.Infof("Processing entry %d", count)
 		}
 
-		vs := vlog.kv.get(e.Key)
+		vs := vlog.kv.get(e.Key, nil)
 		if discardEntry(e, vs) {
 			return nil
 		}
@@ -1044,7 +1044,7 @@ func (vlog *valueLog) doRunGC(lf *logFile, discardRatio float64) (err error) {
 		r.total += esz
 		r.count++
 
-		vs := vlog.kv.get(e.Key)
+		vs := vlog.kv.get(e.Key, nil)
 		if discardEntry(e, vs) {
 			r.discard += esz
 			return nil


### PR DESCRIPTION
- Use RefMap to store referenced table, DecrRef at txn Discard.
- Use y.CompareKeys instead of bytes.Compare