### PR TITLE
use syscall.Fsync for darwin platform.

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -42,7 +42,7 @@ var mmap = flag.Bool("vlog_mmap", true, "Specify if value log must be memory-map
 
 func getTestOptions(dir string) Options {
 	opt := DefaultOptions
-	opt.MaxTableSize = 1 << 15 // Force more compaction.
+	opt.MaxTableSize = 4 << 15 // Force more compaction.
 	opt.LevelOneSize = 4 << 15 // Force more compaction.
 	opt.Dir = dir
 	opt.ValueDir = dir

--- a/fileutil/sync.go
+++ b/fileutil/sync.go
@@ -13,8 +13,3 @@ func Fsync(f *os.File) error {
 func Fdatasync(f *os.File) error {
 	return f.Sync()
 }
-
-// SyncFileRange does nothing on non linux platform.
-func SyncFileRange(f *os.File, offset int64, size int64) error {
-	return nil
-}

--- a/fileutil/sync_darwin.go
+++ b/fileutil/sync_darwin.go
@@ -4,26 +4,18 @@ package fileutil
 
 import (
 	"os"
-
-	"golang.org/x/sys/unix"
+	"syscall"
 )
 
-// Fsync on HFS/OSX flushes the data on to the physical drive but the drive
+// Fsync on darwin platform flushes the data on to the physical drive but the drive
 // may not write it to the persistent media for quite sometime and it may be
-// written in out-of-order sequence. Using F_FULLFSYNC ensures that the
-// physical drive's buffer will also get flushed to the media.
+// written in out-of-order sequence.
 func Fsync(f *os.File) error {
-	_, err := unix.FcntlInt(f.Fd(), unix.F_FULLFSYNC, 0)
+	err := syscall.Fsync(int(f.Fd()))
 	return err
 }
 
-// Fdatasync on darwin platform invokes fcntl(F_FULLFSYNC) for actual persistence
-// on physical drive media.
+// Fdatasync is the same as Fsync on darwin platform.
 func Fdatasync(f *os.File) error {
 	return Fsync(f)
-}
-
-// SyncFileRange does nothing on non linux platform.
-func SyncFileRange(f *os.File, offset int64, size int64) error {
-	return nil
 }

--- a/fileutil/sync_linux.go
+++ b/fileutil/sync_linux.go
@@ -19,21 +19,3 @@ func Fsync(f *os.File) error {
 func Fdatasync(f *os.File) error {
 	return unix.Fdatasync(int(f.Fd()))
 }
-
-// SyncFileRange use sync_file_range() to flush dirty pages.
-// offset is the starting byte of the file range to be synchronized;
-// nbytes specifies the length of the range to be synchronized, in bytes.
-// If nbytes is zero, then all bytes from offset through to the end of file are synchronized.
-// Synchronization is in units of the system page size:
-// offset is rounded down to a page boundary; (offset+nbytes-1) is rounded up to a page boundary.
-// If async is true, just initiate write-out of all dirty pages in the specified range
-// which are not presently submitted write-out. Note that even this may block
-// if you attempt to write more than request queue size.
-// Otherwise it will wait upon write-out of all pages in the range after performing any write.
-//
-// Important: unlike Fdatasync, this function will never update file's metadata (size etc.), which means there are no
-// guarantees that the data will be available after a crash. Please use Fsync or Fdatasync at the end of file write.
-func SyncFileRange(f *os.File, offset int64, nbytes int64) error {
-	flag := unix.SYNC_FILE_RANGE_WRITE | unix.SYNC_FILE_RANGE_WAIT_AFTER | unix.SYNC_FILE_RANGE_WAIT_BEFORE
-	return unix.SyncFileRange(int(f.Fd()), offset, nbytes, flag)
-}


### PR DESCRIPTION
We don’t need to wait for the buffer on the storage device to flush on macOS.

Enlarge the mem table size in test option to speed up the unit test.