### PR TITLE
remove head key and fix bug of table.Smallest()

### DIFF
--- a/compaction.go
+++ b/compaction.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"log"
-	"math"
 	"sync"
 
 	"github.com/coocood/badger/table"
@@ -75,8 +74,8 @@ func getKeyRange(tables []*table.Table) keyRange {
 		}
 	}
 	return keyRange{
-		left:  y.KeyWithTs(y.ParseKey(smallest), math.MaxUint64),
-		right: y.KeyWithTs(y.ParseKey(biggest), 0),
+		left:  smallest,
+		right: biggest,
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -18,6 +18,7 @@ package badger
 
 import (
 	"bytes"
+	"github.com/coocood/badger/protos"
 	"io"
 	"math"
 	"os"
@@ -39,10 +40,7 @@ import (
 )
 
 var (
-	badgerPrefix = []byte("!badger!")     // Prefix for internal keys used by badger.
-	head         = []byte("!badger!head") // For storing value offset for replay.
-	txnKey       = []byte("!badger!txn")  // For indicating end of entries in txn.
-	badgerMove   = []byte("!badger!move") // For key-value pairs which got moved during GC.
+	txnKey = []byte("!badger!txn") // For indicating end of entries in txn.
 )
 
 type closers struct {
@@ -296,13 +294,12 @@ func Open(opt Options) (db *DB, err error) {
 		return nil, err
 	}
 
-	headKey := y.KeyWithTs(head, math.MaxUint64)
-	// Need to pass with timestamp, lsm get removes the last 8 bytes and compares key
-	vs := db.get(headKey, nil)
-	db.orc.curRead = vs.Version
 	var logOff logOffset
-	if len(vs.Value) > 0 {
-		logOff.Decode(vs.Value)
+	head := manifest.Head
+	if head != nil {
+		db.orc.curRead = head.Version
+		logOff.fid = head.LogID
+		logOff.offset = head.LogOffset
 	}
 
 	// lastUsedCasCounter will either be the value stored in !badger!head, or some subsequently
@@ -768,15 +765,17 @@ func (db *DB) runFlushMemTable(c *y.Closer) error {
 		if ft.mt == nil {
 			return nil
 		}
-
+		var headInfo *protos.HeadInfo
 		if !ft.mt.Empty() {
+			headInfo = &protos.HeadInfo{
+				// Pick the max commit ts, so in case of crash, our read ts would be higher than all the
+				// commits.
+				Version:   db.orc.commitTs(),
+				LogID:     ft.off.fid,
+				LogOffset: ft.off.offset,
+			}
 			// Store badger head even if vptr is zero, need it for readTs
 			log.Infof("Storing offset: %+v\n", ft.off)
-
-			// Pick the max commit ts, so in case of crash, our read ts would be higher than all the
-			// commits.
-			headTs := y.KeyWithTs(head, db.orc.commitTs())
-			ft.mt.PutToSkl(headTs, y.ValueStruct{Value: ft.off.Encode()})
 		}
 
 		fileID := db.lc.reserveFileID()
@@ -812,7 +811,7 @@ func (db *DB) runFlushMemTable(c *y.Closer) error {
 			return err
 		}
 		// We own a ref on tbl.
-		err = db.lc.addLevel0Table(tbl) // This will incrRef (if we don't error, sure)
+		err = db.lc.addLevel0Table(tbl, headInfo) // This will incrRef (if we don't error, sure)
 		tbl.DecrRef()                   // Releases our ref.
 		if err != nil {
 			return err

--- a/db.go
+++ b/db.go
@@ -812,7 +812,7 @@ func (db *DB) runFlushMemTable(c *y.Closer) error {
 		}
 		// We own a ref on tbl.
 		err = db.lc.addLevel0Table(tbl, headInfo) // This will incrRef (if we don't error, sure)
-		tbl.DecrRef()                   // Releases our ref.
+		tbl.DecrRef()                             // Releases our ref.
 		if err != nil {
 			return err
 		}

--- a/levels.go
+++ b/levels.go
@@ -848,7 +848,7 @@ func (lc *levelsController) runCompactDef(l int, cd compactDef, limiter *rate.Li
 	}
 
 	// We write to the manifest _before_ we delete files (and after we created files)
-	if err := lc.kv.manifest.addChanges(changeSet.Changes); err != nil {
+	if err := lc.kv.manifest.addChanges(changeSet.Changes, nil); err != nil {
 		return err
 	}
 
@@ -907,14 +907,14 @@ func (lc *levelsController) doCompact(p compactionPriority) (bool, error) {
 	return true, nil
 }
 
-func (lc *levelsController) addLevel0Table(t *table.Table) error {
+func (lc *levelsController) addLevel0Table(t *table.Table, head *protos.HeadInfo) error {
 	// We update the manifest _before_ the table becomes part of a levelHandler, because at that
 	// point it could get used in some compaction.  This ensures the manifest file gets updated in
 	// the proper order. (That means this update happens before that of some compaction which
 	// deletes the table.)
 	err := lc.kv.manifest.addChanges([]*protos.ManifestChange{
 		makeTableCreateChange(t.ID(), 0),
-	})
+	}, head)
 	if err != nil {
 		return err
 	}

--- a/levels.go
+++ b/levels.go
@@ -19,7 +19,6 @@ package badger
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"math/rand"
 	"os"
 	"sort"
@@ -696,10 +695,8 @@ func (lc *levelsController) fillTables(cd *compactDef) bool {
 	for _, t := range tbls {
 		cd.thisSize = t.Size()
 		cd.thisRange = keyRange{
-			// We pick all the versions of the smallest and the biggest key.
-			left: y.KeyWithTs(y.ParseKey(t.Smallest()), math.MaxUint64),
-			// Note that version zero would be the rightmost key.
-			right: y.KeyWithTs(y.ParseKey(t.Biggest()), 0),
+			left:  t.Smallest(),
+			right: t.Biggest(),
 		}
 		if lc.cstatus.overlapsWith(cd.thisLevel.level, cd.thisRange) {
 			continue
@@ -854,7 +851,7 @@ func (lc *levelsController) runCompactDef(l int, cd compactDef, limiter *rate.Li
 
 	// See comment earlier in this function about the ordering of these ops, and the order in which
 	// we access levels when reading.
-	if err := nextLevel.replaceTables(newTables, cd.skippedTbls); err != nil {
+	if err := nextLevel.replaceTables(newTables, &cd); err != nil {
 		return err
 	}
 	if err := thisLevel.deleteTables(cd.top); err != nil {

--- a/protos/backup.pb.go
+++ b/protos/backup.pb.go
@@ -11,6 +11,7 @@
 	It has these top-level messages:
 		KVPair
 		ManifestChangeSet
+		HeadInfo
 		ManifestChange
 */
 package protos

--- a/protos/manifest.pb.go
+++ b/protos/manifest.pb.go
@@ -37,12 +37,13 @@ func (x ManifestChange_Operation) String() string {
 	return proto.EnumName(ManifestChange_Operation_name, int32(x))
 }
 func (ManifestChange_Operation) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptorManifest, []int{1, 0}
+	return fileDescriptorManifest, []int{2, 0}
 }
 
 type ManifestChangeSet struct {
 	// A set of changes that are applied atomically.
 	Changes []*ManifestChange `protobuf:"bytes,1,rep,name=changes" json:"changes,omitempty"`
+	Head    *HeadInfo         `protobuf:"bytes,2,opt,name=head" json:"head,omitempty"`
 }
 
 func (m *ManifestChangeSet) Reset()                    { *m = ManifestChangeSet{} }
@@ -57,6 +58,45 @@ func (m *ManifestChangeSet) GetChanges() []*ManifestChange {
 	return nil
 }
 
+func (m *ManifestChangeSet) GetHead() *HeadInfo {
+	if m != nil {
+		return m.Head
+	}
+	return nil
+}
+
+type HeadInfo struct {
+	Version   uint64 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
+	LogID     uint32 `protobuf:"varint,2,opt,name=logID,proto3" json:"logID,omitempty"`
+	LogOffset uint32 `protobuf:"varint,3,opt,name=logOffset,proto3" json:"logOffset,omitempty"`
+}
+
+func (m *HeadInfo) Reset()                    { *m = HeadInfo{} }
+func (m *HeadInfo) String() string            { return proto.CompactTextString(m) }
+func (*HeadInfo) ProtoMessage()               {}
+func (*HeadInfo) Descriptor() ([]byte, []int) { return fileDescriptorManifest, []int{1} }
+
+func (m *HeadInfo) GetVersion() uint64 {
+	if m != nil {
+		return m.Version
+	}
+	return 0
+}
+
+func (m *HeadInfo) GetLogID() uint32 {
+	if m != nil {
+		return m.LogID
+	}
+	return 0
+}
+
+func (m *HeadInfo) GetLogOffset() uint32 {
+	if m != nil {
+		return m.LogOffset
+	}
+	return 0
+}
+
 type ManifestChange struct {
 	Id    uint64                   `protobuf:"varint,1,opt,name=Id,proto3" json:"Id,omitempty"`
 	Op    ManifestChange_Operation `protobuf:"varint,2,opt,name=Op,proto3,enum=protos.ManifestChange_Operation" json:"Op,omitempty"`
@@ -66,7 +106,7 @@ type ManifestChange struct {
 func (m *ManifestChange) Reset()                    { *m = ManifestChange{} }
 func (m *ManifestChange) String() string            { return proto.CompactTextString(m) }
 func (*ManifestChange) ProtoMessage()               {}
-func (*ManifestChange) Descriptor() ([]byte, []int) { return fileDescriptorManifest, []int{1} }
+func (*ManifestChange) Descriptor() ([]byte, []int) { return fileDescriptorManifest, []int{2} }
 
 func (m *ManifestChange) GetId() uint64 {
 	if m != nil {
@@ -91,6 +131,7 @@ func (m *ManifestChange) GetLevel() uint32 {
 
 func init() {
 	proto.RegisterType((*ManifestChangeSet)(nil), "protos.ManifestChangeSet")
+	proto.RegisterType((*HeadInfo)(nil), "protos.HeadInfo")
 	proto.RegisterType((*ManifestChange)(nil), "protos.ManifestChange")
 	proto.RegisterEnum("protos.ManifestChange_Operation", ManifestChange_Operation_name, ManifestChange_Operation_value)
 }
@@ -120,6 +161,49 @@ func (m *ManifestChangeSet) MarshalTo(dAtA []byte) (int, error) {
 			}
 			i += n
 		}
+	}
+	if m.Head != nil {
+		dAtA[i] = 0x12
+		i++
+		i = encodeVarintManifest(dAtA, i, uint64(m.Head.Size()))
+		n1, err := m.Head.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n1
+	}
+	return i, nil
+}
+
+func (m *HeadInfo) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *HeadInfo) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if m.Version != 0 {
+		dAtA[i] = 0x8
+		i++
+		i = encodeVarintManifest(dAtA, i, uint64(m.Version))
+	}
+	if m.LogID != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintManifest(dAtA, i, uint64(m.LogID))
+	}
+	if m.LogOffset != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintManifest(dAtA, i, uint64(m.LogOffset))
 	}
 	return i, nil
 }
@@ -174,6 +258,25 @@ func (m *ManifestChangeSet) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovManifest(uint64(l))
 		}
+	}
+	if m.Head != nil {
+		l = m.Head.Size()
+		n += 1 + l + sovManifest(uint64(l))
+	}
+	return n
+}
+
+func (m *HeadInfo) Size() (n int) {
+	var l int
+	_ = l
+	if m.Version != 0 {
+		n += 1 + sovManifest(uint64(m.Version))
+	}
+	if m.LogID != 0 {
+		n += 1 + sovManifest(uint64(m.LogID))
+	}
+	if m.LogOffset != 0 {
+		n += 1 + sovManifest(uint64(m.LogOffset))
 	}
 	return n
 }
@@ -266,6 +369,146 @@ func (m *ManifestChangeSet) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Head", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowManifest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthManifest
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Head == nil {
+				m.Head = &HeadInfo{}
+			}
+			if err := m.Head.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipManifest(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthManifest
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *HeadInfo) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowManifest
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: HeadInfo: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: HeadInfo: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Version", wireType)
+			}
+			m.Version = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowManifest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Version |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LogID", wireType)
+			}
+			m.LogID = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowManifest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.LogID |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LogOffset", wireType)
+			}
+			m.LogOffset = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowManifest
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.LogOffset |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skipManifest(dAtA[iNdEx:])
@@ -502,19 +745,24 @@ var (
 func init() { proto.RegisterFile("manifest.proto", fileDescriptorManifest) }
 
 var fileDescriptorManifest = []byte{
-	// 223 bytes of a gzipped FileDescriptorProto
+	// 297 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0xe2, 0xcb, 0x4d, 0xcc, 0xcb,
 	0x4c, 0x4b, 0x2d, 0x2e, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x03, 0x53, 0xc5, 0x4a,
-	0xae, 0x5c, 0x82, 0xbe, 0x50, 0x19, 0xe7, 0x8c, 0xc4, 0xbc, 0xf4, 0xd4, 0xe0, 0xd4, 0x12, 0x21,
+	0xd9, 0x5c, 0x82, 0xbe, 0x50, 0x19, 0xe7, 0x8c, 0xc4, 0xbc, 0xf4, 0xd4, 0xe0, 0xd4, 0x12, 0x21,
 	0x03, 0x2e, 0xf6, 0x64, 0x30, 0xa7, 0x58, 0x82, 0x51, 0x81, 0x59, 0x83, 0xdb, 0x48, 0x0c, 0xa2,
-	0xab, 0x58, 0x0f, 0x55, 0x6d, 0x10, 0x4c, 0x99, 0xd2, 0x1c, 0x46, 0x2e, 0x3e, 0x54, 0x39, 0x21,
-	0x3e, 0x2e, 0x26, 0xcf, 0x14, 0x09, 0x46, 0x05, 0x46, 0x0d, 0x96, 0x20, 0x26, 0xcf, 0x14, 0x21,
-	0x03, 0x2e, 0x26, 0xff, 0x02, 0x09, 0x26, 0x05, 0x46, 0x0d, 0x3e, 0x23, 0x05, 0xec, 0xe6, 0xe9,
-	0xf9, 0x17, 0xa4, 0x16, 0x25, 0x96, 0x64, 0xe6, 0xe7, 0x05, 0x31, 0xf9, 0x17, 0x08, 0x89, 0x70,
-	0xb1, 0xfa, 0xa4, 0x96, 0xa5, 0xe6, 0x48, 0x30, 0x2b, 0x30, 0x6a, 0xf0, 0x06, 0x41, 0x38, 0x4a,
-	0x46, 0x5c, 0x9c, 0x70, 0x65, 0x42, 0x5c, 0x5c, 0x6c, 0xce, 0x41, 0xae, 0x8e, 0x21, 0xae, 0x02,
-	0x0c, 0x20, 0xb6, 0x8b, 0xab, 0x8f, 0x6b, 0x88, 0xab, 0x00, 0xa3, 0x10, 0x2f, 0x17, 0xa7, 0xaf,
-	0x7f, 0x98, 0x6b, 0xbc, 0x8b, 0x7f, 0xb8, 0x9f, 0x00, 0x93, 0x93, 0xc0, 0x89, 0x47, 0x72, 0x8c,
-	0x17, 0x1e, 0xc9, 0x31, 0x3e, 0x78, 0x24, 0xc7, 0x38, 0xe3, 0xb1, 0x1c, 0x43, 0x12, 0xc4, 0xff,
-	0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x45, 0x50, 0x87, 0x64, 0x18, 0x01, 0x00, 0x00,
+	0xab, 0x58, 0x0f, 0x55, 0x6d, 0x10, 0x4c, 0x99, 0x90, 0x0a, 0x17, 0x4b, 0x46, 0x6a, 0x62, 0x8a,
+	0x04, 0x93, 0x02, 0xa3, 0x06, 0xb7, 0x91, 0x00, 0x4c, 0xb9, 0x47, 0x6a, 0x62, 0x8a, 0x67, 0x5e,
+	0x5a, 0x7e, 0x10, 0x58, 0x56, 0x29, 0x82, 0x8b, 0x03, 0x26, 0x22, 0x24, 0xc1, 0xc5, 0x5e, 0x96,
+	0x5a, 0x54, 0x9c, 0x99, 0x9f, 0x27, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x12, 0x04, 0xe3, 0x0a, 0x89,
+	0x70, 0xb1, 0xe6, 0xe4, 0xa7, 0x7b, 0xba, 0x80, 0x0d, 0xe3, 0x0d, 0x82, 0x70, 0x84, 0x64, 0xb8,
+	0x38, 0x73, 0xf2, 0xd3, 0xfd, 0xd3, 0xd2, 0x8a, 0x53, 0x4b, 0x24, 0x98, 0xc1, 0x32, 0x08, 0x01,
+	0xa5, 0x39, 0x8c, 0x5c, 0x7c, 0xa8, 0x6e, 0x13, 0xe2, 0xe3, 0x62, 0xf2, 0x4c, 0x81, 0x9a, 0xcd,
+	0xe4, 0x99, 0x22, 0x64, 0xc0, 0xc5, 0xe4, 0x5f, 0x00, 0x36, 0x93, 0xcf, 0x48, 0x01, 0xbb, 0x7f,
+	0xf4, 0xfc, 0x0b, 0x52, 0x8b, 0x12, 0x4b, 0x32, 0xf3, 0xf3, 0x82, 0x98, 0xfc, 0x0b, 0x40, 0x0e,
+	0xf1, 0x49, 0x2d, 0x4b, 0xcd, 0x81, 0x5a, 0x07, 0xe1, 0x28, 0x19, 0x71, 0x71, 0xc2, 0x95, 0x09,
+	0x71, 0x71, 0xb1, 0x39, 0x07, 0xb9, 0x3a, 0x86, 0xb8, 0x0a, 0x30, 0x80, 0xd8, 0x2e, 0xae, 0x3e,
+	0xae, 0x21, 0xae, 0x02, 0x8c, 0x42, 0xbc, 0x5c, 0x9c, 0xbe, 0xfe, 0x61, 0xae, 0xf1, 0x2e, 0xfe,
+	0xe1, 0x7e, 0x02, 0x4c, 0x4e, 0x02, 0x27, 0x1e, 0xc9, 0x31, 0x5e, 0x78, 0x24, 0xc7, 0xf8, 0xe0,
+	0x91, 0x1c, 0xe3, 0x8c, 0xc7, 0x72, 0x0c, 0x49, 0x90, 0xf0, 0x37, 0x06, 0x04, 0x00, 0x00, 0xff,
+	0xff, 0x3a, 0x13, 0x93, 0x83, 0x98, 0x01, 0x00, 0x00,
 }

--- a/protos/manifest.proto
+++ b/protos/manifest.proto
@@ -22,6 +22,13 @@ package protos;
 message ManifestChangeSet {
         // A set of changes that are applied atomically.
         repeated ManifestChange changes = 1;
+        HeadInfo head = 2;
+}
+
+message HeadInfo {
+        uint64 version   = 1;
+        uint32 logID     = 2;
+        uint32 logOffset = 3;
 }
 
 message ManifestChange {

--- a/table/builder.go
+++ b/table/builder.go
@@ -254,9 +254,13 @@ func (b *Builder) Finish() error {
 	if err := b.w.Append(b.buf); err != nil {
 		return err
 	}
-
+	ts := uint64(math.MaxUint64)
+	if b.isExternal {
+		// External builder doesn't append ts to the keys, the output sst should has a non-MaxUint64 global ts.
+		ts = math.MaxUint64 - 1
+	}
 	var tsBuf [8]byte
-	binary.BigEndian.PutUint64(tsBuf[:], math.MaxUint64)
+	binary.BigEndian.PutUint64(tsBuf[:], ts)
 	if err := b.w.Append(tsBuf[:]); err != nil {
 		return err
 	}

--- a/table/iterator.go
+++ b/table/iterator.go
@@ -363,6 +363,14 @@ func (itr *Iterator) Key() []byte {
 	return itr.bi.key
 }
 
+func (itr *Iterator) RawKey() []byte {
+	if itr.t.HasGlobalTs() {
+		return itr.bi.key
+	} else {
+		return y.ParseKey(itr.bi.key)
+	}
+}
+
 // Value follows the y.Iterator interface
 func (itr *Iterator) Value() (ret y.ValueStruct) {
 	ret.Decode(itr.bi.val)

--- a/table/table.go
+++ b/table/table.go
@@ -146,14 +146,16 @@ func OpenTable(fd *os.File, loadingMode options.FileLoadingMode) (*Table, error)
 	defer it.Close()
 	it.Rewind()
 	if it.Valid() {
-		t.smallest = it.Key()
+		// key with max ts is the binary smallest key.
+		t.smallest = y.KeyWithTs(it.RawKey(), math.MaxUint64)
 	}
 
 	it2 := t.NewIterator(true)
 	defer it2.Close()
 	it2.Rewind()
 	if it2.Valid() {
-		t.biggest = it2.Key()
+		// key with 0 ts is the binary biggest key.
+		t.biggest = y.KeyWithTs(it2.RawKey(), 0)
 	}
 	return t, nil
 }
@@ -306,8 +308,6 @@ func (t *Table) SetGlobalTs(ts uint64) error {
 		return err
 	}
 	t.globalTs = encodeTs
-	t.smallest = y.KeyWithTs(t.smallest, ts)
-	t.biggest = y.KeyWithTs(t.biggest, ts)
 	return nil
 }
 

--- a/value_test.go
+++ b/value_test.go
@@ -52,7 +52,7 @@ func TestValueBasic(t *testing.T) {
 		meta:  bitTxn,
 	}
 	eFin := &Entry{
-		Key:  y.KeyWithTs(head, 100),
+		Key:  y.KeyWithTs(txnKey, 100),
 		meta: bitFinTxn,
 	}
 	offset := log.getMaxPtr()

--- a/writer_ingest.go
+++ b/writer_ingest.go
@@ -125,7 +125,7 @@ func (w *writeWorker) ingestTable(tbl *table.Table, splitHints [][]byte) error {
 	}
 
 	change := makeTableCreateChange(tbl.ID(), targetLevel)
-	if err := w.manifest.addChanges([]*protos.ManifestChange{change}); err != nil {
+	if err := w.manifest.addChanges([]*protos.ManifestChange{change}, nil); err != nil {
 		return err
 	}
 	w.lc.levels[targetLevel].addTable(tbl)
@@ -152,7 +152,7 @@ func (w *writeWorker) runIngestCompact(level int, tbl *table.Table, overlappingT
 		changes = append(changes, makeTableDeleteChange(t.ID()))
 	}
 
-	if err := w.manifest.addChanges(changes); err != nil {
+	if err := w.manifest.addChanges(changes, nil); err != nil {
 		return err
 	}
 	return cd.nextLevel.replaceTables(newTables, cd.skippedTbls)

--- a/writer_ingest.go
+++ b/writer_ingest.go
@@ -1,7 +1,6 @@
 package badger
 
 import (
-	"math"
 	"sync"
 
 	"github.com/coocood/badger/protos"
@@ -65,7 +64,7 @@ func (w *writeWorker) prepareIngestTask(task *ingestTask) (ts uint64, wg *sync.W
 	it := w.mt.NewIterator(false)
 	defer it.Close()
 	for _, t := range task.tbls {
-		it.Seek(y.KeyWithTs(t.Smallest(), math.MaxUint64))
+		it.Seek(t.Smallest())
 		if it.Valid() && y.CompareKeysWithVer(it.Key(), y.KeyWithTs(t.Biggest(), 0)) <= 0 {
 			if wg, err = w.flushMemTable(); err != nil {
 				return
@@ -136,6 +135,7 @@ func (w *writeWorker) runIngestCompact(level int, tbl *table.Table, overlappingT
 	cd := compactDef{
 		nextLevel: w.lc.levels[level],
 		top:       []*table.Table{tbl},
+		nextRange: getKeyRange(overlappingTables),
 	}
 	w.lc.fillBottomTables(&cd, overlappingTables)
 	newTables, err := w.lc.compactBuildTables(level-1, cd, w.limiter, splitHints)
@@ -155,7 +155,7 @@ func (w *writeWorker) runIngestCompact(level int, tbl *table.Table, overlappingT
 	if err := w.manifest.addChanges(changes, nil); err != nil {
 		return err
 	}
-	return cd.nextLevel.replaceTables(newTables, cd.skippedTbls)
+	return cd.nextLevel.replaceTables(newTables, &cd)
 }
 
 func (w *writeWorker) overlapWithFlushingMemTables(kr keyRange) bool {


### PR DESCRIPTION
- Move the information in the head key to the manefest, reduce compaction cost.
- Fix bug that the smallest key in the table is not the smallest.
- Fix bug in `levelHandler.replaceTables`, should not return when `len(newTables) == 0`.