### PR TITLE
support blob read ahead cache

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -89,7 +89,7 @@ func (item *Item) Value() ([]byte, error) {
 			item.slice = new(y.Slice)
 		}
 		if item.txn.blobCache == nil {
-			item.txn.blobCache = map[uint32]*blobFile{}
+			item.txn.blobCache = map[uint32]*blobCache{}
 		}
 		return item.db.blobManger.read(item.vptr, item.slice, item.txn.blobCache)
 	}

--- a/transaction.go
+++ b/transaction.go
@@ -160,7 +160,7 @@ type Txn struct {
 	size         int64
 	count        int64
 	numIterators int32
-	blobCache    map[uint32]*blobFile
+	blobCache    map[uint32]*blobCache
 }
 
 type pendingWritesIterator struct {
@@ -434,8 +434,8 @@ func (txn *Txn) Discard() {
 	}
 	txn.discarded = true
 	txn.db.orc.readMark.Done(txn.wmNode)
-	for _, blob := range txn.blobCache {
-		blob.decrRef()
+	for _, bc := range txn.blobCache {
+		bc.file.decrRef()
 	}
 	txn.blobCache = nil
 	if txn.update {


### PR DESCRIPTION
Sysbench 30 million rows. `select count(c) from sbtest1` improved from 55 seconds to 0.85 seconds.