### PR TITLE
return the correct raw key if sst has global ts

### DIFF
--- a/table/iterator.go
+++ b/table/iterator.go
@@ -377,11 +377,7 @@ func (itr *Iterator) Key() []byte {
 }
 
 func (itr *Iterator) RawKey() []byte {
-	if itr.t.HasGlobalTs() {
-		return itr.bi.key
-	} else {
-		return y.ParseKey(itr.bi.key)
-	}
+	return y.ParseKey(itr.bi.key)
 }
 
 // Value follows the y.Iterator interface


### PR DESCRIPTION
If `tbl.HasGlobalKey()`, the `itr.bi.key` has append this ts to the key.