### PR TITLE
Use different option for max mem-table size and max table-file size.

### DIFF
--- a/blob_test.go
+++ b/blob_test.go
@@ -17,6 +17,7 @@ func TestBlob(t *testing.T) {
 	opts := getTestOptions(dir)
 	opts.ValueThreshold = 20
 	opts.MaxTableSize = 4 * 1024
+	opts.MaxMemTableSize = 4 * 1024
 	opts.NumMemtables = 2
 	opts.NumLevelZeroTables = 1
 	opts.NumLevelZeroTablesStall = 2
@@ -70,6 +71,7 @@ func TestBlobGC(t *testing.T) {
 	opts := getTestOptions(dir)
 	opts.ValueThreshold = 20
 	opts.MaxTableSize = 6 * 1024
+	opts.MaxMemTableSize = 6 * 1024
 	opts.NumMemtables = 2
 	opts.NumLevelZeroTables = 1
 	opts.NumLevelZeroTablesStall = 2

--- a/db_test.go
+++ b/db_test.go
@@ -50,8 +50,9 @@ func getTestCompression(tp options.CompressionType) []options.CompressionType {
 
 func getTestOptions(dir string) Options {
 	opt := DefaultOptions
-	opt.MaxTableSize = 4 << 15 // Force more compaction.
-	opt.LevelOneSize = 4 << 15 // Force more compaction.
+	opt.MaxTableSize = 4 << 15    // Force more compaction.
+	opt.MaxMemTableSize = 4 << 15 // Force more compaction.
+	opt.LevelOneSize = 4 << 15    // Force more compaction.
 	opt.Dir = dir
 	opt.ValueDir = dir
 	opt.SyncWrites = false
@@ -1158,6 +1159,7 @@ func TestCompactionFilter(t *testing.T) {
 	opts := getTestOptions(dir)
 	opts.ValueThreshold = 8 * 1024
 	opts.MaxTableSize = 32 * 1024
+	opts.MaxMemTableSize = 32 * 1024
 	opts.NumMemtables = 2
 	opts.NumLevelZeroTables = 1
 	opts.NumLevelZeroTablesStall = 2
@@ -1293,6 +1295,7 @@ func TestIterateVLog(t *testing.T) {
 	defer os.RemoveAll(dir)
 	opts := getTestOptions(dir)
 	opts.MaxTableSize = 1 << 20
+	opts.MaxMemTableSize = 1 << 20
 	opts.ValueLogFileSize = 1 << 20
 	opts.ValueThreshold = 1000
 	opts.ValueLogMaxNumFiles = 1000

--- a/options.go
+++ b/options.go
@@ -46,7 +46,8 @@ type Options struct {
 	// 3. Flags that user might want to review
 	// ----------------------------------------
 	// The following affect all levels of LSM tree.
-	MaxTableSize int64 // Each table (or file) is at most this size.
+	MaxMemTableSize int64 // Each mem table is at most this size.
+	MaxTableSize    int64 // Each table file is at most this size.
 	// If value size >= this threshold, only store value offsets in tree.
 	// If set to 0, all values are stored in SST.
 	ValueThreshold int
@@ -77,9 +78,6 @@ type Options struct {
 
 	// Number of compaction workers to run concurrently.
 	NumCompactors int
-
-	// Max number of sub compaction, set 1 or 0 to disable sub compaction.
-	MaxSubCompaction int
 
 	// Transaction start and commit timestamps are manaVgedTxns by end-user. This
 	// is a private option used by ManagedDB.
@@ -145,13 +143,11 @@ const (
 // DefaultOptions sets a list of recommended options for good performance.
 // Feel free to modify these to suit your needs.
 var DefaultOptions = Options{
-	DoNotCompact: false,
-	LevelOneSize: 256 << 20,
-	// table.MemoryMap to mmap() the tables.
-	// table.Nothing to not preload the tables.
-	MaxTableSize:            64 << 20,
+	DoNotCompact:            false,
+	LevelOneSize:            256 << 20,
+	MaxMemTableSize:         64 << 20,
+	MaxTableSize:            8 << 20,
 	NumCompactors:           3,
-	MaxSubCompaction:        3,
 	NumLevelZeroTables:      5,
 	NumLevelZeroTablesStall: 10,
 	NumMemtables:            5,

--- a/table/table.go
+++ b/table/table.go
@@ -402,6 +402,17 @@ func (t *Table) HasOverlap(start, end []byte, includeEnd bool) bool {
 	if t.surf != nil {
 		return t.surf.HasOverlap(start, end, includeEnd)
 	}
+
+	it := t.NewIterator(false)
+	it.Seek(start)
+	if !it.Valid() {
+		return false
+	}
+	if cmp := y.CompareKeysWithVer(it.Key(), end); cmp > 0 {
+		return false
+	} else if cmp == 0 {
+		return includeEnd
+	}
 	return true
 }
 

--- a/table/table.go
+++ b/table/table.go
@@ -402,17 +402,6 @@ func (t *Table) HasOverlap(start, end []byte, includeEnd bool) bool {
 	if t.surf != nil {
 		return t.surf.HasOverlap(start, end, includeEnd)
 	}
-
-	it := t.NewIterator(false)
-	it.Seek(start)
-	if !it.Valid() {
-		return false
-	}
-	if cmp := y.CompareKeysWithVer(it.Key(), end); cmp > 0 {
-		return false
-	} else if cmp == 0 {
-		return includeEnd
-	}
 	return true
 }
 

--- a/transaction.go
+++ b/transaction.go
@@ -245,7 +245,7 @@ func (txn *Txn) checkSize(e *Entry) error {
 	}
 	// Extra bytes for version in key.
 	size := int64(e.estimateSize()) + 10
-	if size >= txn.db.opt.MaxTableSize {
+	if size >= txn.db.opt.MaxMemTableSize {
 		return ErrTxnTooBig
 	}
 	txn.count++

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -801,6 +801,7 @@ func TestArmV7Issue311Fix(t *testing.T) {
 	config.ValueLogFileSize = 16 << 20
 	config.LevelOneSize = 8 << 20
 	config.MaxTableSize = 2 << 20
+	config.MaxMemTableSize = 2 << 20
 	config.Dir = dir
 	config.ValueDir = dir
 	config.SyncWrites = false

--- a/writer.go
+++ b/writer.go
@@ -225,7 +225,7 @@ func (w *writeWorker) writeToLSM(entries []*Entry) error {
 	for len(entries) != 0 {
 		e := newEntry(entries[0])
 		free := w.ensureRoomForWrite(mTbls.getMutable(), e.EstimateSize())
-		if free == w.opt.MaxTableSize {
+		if free == w.opt.MaxMemTableSize {
 			mTbls = w.mtbls.Load().(*memTables)
 		}
 


### PR DESCRIPTION
So we can set the table file to be much smaller to reduce compaction cost.