### PR TITLE
Managed DB support set commit version for each entry.

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -132,6 +132,11 @@ func (item *Item) IsDeleted() bool {
 	return isDeleted(item.meta)
 }
 
+// IsHidden returns true if item is hidden.
+func (item *Item) IsHidden() bool {
+	return isHidden(item.meta)
+}
+
 // EstimatedSize returns approximate size of the key-value pair.
 //
 // This can be called while iterating through a store to quickly estimate the
@@ -357,6 +362,10 @@ func (it *Iterator) parseItemForward() {
 				iitr.Next()
 				continue
 			}
+			if isHidden(it.vs.Meta) && !it.txn.readHidden {
+				iitr.Next()
+				continue
+			}
 		} else {
 			iitr.FillValue(&it.vs)
 		}
@@ -384,6 +393,10 @@ func possibleSameKey(aKey, bKey []byte) bool {
 
 func isDeleted(meta byte) bool {
 	return meta&bitDelete > 0
+}
+
+func isHidden(meta byte) bool {
+	return meta&bitHidden > 0
 }
 
 func (it *Iterator) setItem(item *Item) {
@@ -427,6 +440,10 @@ FILL:
 	// If deleted, advance and return.
 	mi.FillValue(&it.vs)
 	if isDeleted(it.vs.Meta) {
+		mi.Next()
+		return false
+	}
+	if isHidden(it.vs.Meta) && !it.txn.readHidden {
 		mi.Next()
 		return false
 	}
@@ -503,4 +520,8 @@ func (it *Iterator) Rewind() {
 	}
 	it.iitr.Rewind()
 	it.parseItemReverse()
+}
+
+func (it *Iterator) SetAllVersions(allVersions bool) {
+	it.opt.AllVersions = allVersions
 }

--- a/levels.go
+++ b/levels.go
@@ -969,17 +969,16 @@ func (s *levelsController) get(key y.Key, keyHash uint64) y.ValueStruct {
 	for _, h := range s.levels {
 		vs := h.get(key, keyHash) // Calls h.RLock() and h.RUnlock().
 		if vs.Valid() {
-			log.Info("got in level", h.level)
 			return vs
 		}
 	}
 	return y.ValueStruct{}
 }
 
-func (s *levelsController) multiGet(pairs []keyValuePair) {
+func (s *levelsController) multiGet(pairs []keyValuePair, readHidden bool) {
 	start := time.Now()
 	for _, h := range s.levels {
-		h.multiGet(pairs)
+		h.multiGet(pairs, readHidden)
 	}
 	s.kv.metrics.LSMMultiGetDuration.Observe(time.Since(start).Seconds())
 }

--- a/managed_db.go
+++ b/managed_db.go
@@ -34,7 +34,7 @@ type ManagedDB struct {
 // This is only useful for databases built on top of Badger (like Dgraph), and
 // can be ignored by most users.
 func OpenManaged(opts Options) (*ManagedDB, error) {
-	opts.managedTxns = true
+	opts.ManagedTxns = true
 	db, err := Open(opts)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (db *ManagedDB) NewTransactionAt(readTs uint64, update bool) *Txn {
 // This is only useful for databases built on top of Badger (like Dgraph), and
 // can be ignored by most users.
 func (txn *Txn) CommitAt(commitTs uint64) error {
-	if !txn.db.opt.managedTxns {
+	if !txn.db.IsManaged() {
 		return ErrManagedTxn
 	}
 	txn.commitTs = commitTs

--- a/options.go
+++ b/options.go
@@ -79,9 +79,9 @@ type Options struct {
 	// Number of compaction workers to run concurrently.
 	NumCompactors int
 
-	// Transaction start and commit timestamps are manaVgedTxns by end-user. This
-	// is a private option used by ManagedDB.
-	managedTxns bool
+	// Transaction start and commit timestamps are managed by end-user.
+	// A managed transaction can only set values by SetEntry with a non-zero version key.
+	ManagedTxns bool
 
 	// 4. Flags for testing purposes
 	// ------------------------------

--- a/structs.go
+++ b/structs.go
@@ -63,6 +63,16 @@ type Entry struct {
 	offset uint32
 }
 
+// SetHidden makes the entry a hidden entry.
+// A hidden entry can only be read if Transaction.ReadHidden is set.
+func (e *Entry) SetHidden() {
+	e.meta |= bitHidden
+}
+
+func (e *Entry) SetDelete() {
+	e.meta |= bitDelete
+}
+
 func (e *Entry) estimateSize() int {
 	return e.Key.Len() + len(e.Value) + len(e.UserMeta) + 2 // Meta, UserMeta
 }

--- a/value.go
+++ b/value.go
@@ -41,6 +41,7 @@ import (
 const (
 	bitDelete       byte = 1 << 0 // Set if the key has been deleted.
 	bitValuePointer byte = 1 << 1 // Set if the value is NOT stored directly next to key.
+	bitHidden       byte = 1 << 2 // Set if the value is not visible to normal transaction.
 
 	// The MSB 2 bits are for transactions.
 	bitTxn    byte = 1 << 6 // Set if the entry is part of a txn.


### PR DESCRIPTION
- Support hidden entry which can only be visible if ReadHidden is set.
- Support SetReadTS to update ReadTS for a transaction.
- Support UpdateSafeTS for GC old version on managed DB.