### PR TITLE
add volatile mode and close background workers

### DIFF
--- a/db.go
+++ b/db.go
@@ -590,14 +590,6 @@ func (db *DB) Close() (err error) {
 		db.closers.compactors.SignalAndWait()
 		log.Infof("Compaction finished")
 	}
-	if db.closers.blobManager != nil {
-		db.closers.blobManager.SignalAndWait()
-		log.Infof("BlobManager finished")
-	}
-	if db.closers.resourceManager != nil {
-		db.closers.resourceManager.SignalAndWait()
-		log.Infof("ResourceManager finished")
-	}
 	if db.opt.CompactL0WhenClose && !db.volatileMode {
 		// Force Compact L0
 		// We don't need to care about cstatus since no parallel compaction is running.
@@ -614,6 +606,15 @@ func (db *DB) Close() (err error) {
 		} else {
 			log.Infof("fillTables failed for level zero. No compaction required")
 		}
+	}
+
+	if db.closers.blobManager != nil {
+		db.closers.blobManager.SignalAndWait()
+		log.Infof("BlobManager finished")
+	}
+	if db.closers.resourceManager != nil {
+		db.closers.resourceManager.SignalAndWait()
+		log.Infof("ResourceManager finished")
 	}
 
 	if lcErr := db.lc.close(); err == nil {

--- a/db.go
+++ b/db.go
@@ -47,10 +47,12 @@ var (
 )
 
 type closers struct {
-	updateSize *y.Closer
-	compactors *y.Closer
-	memtable   *y.Closer
-	writes     *y.Closer
+	updateSize      *y.Closer
+	compactors      *y.Closer
+	resourceManager *y.Closer
+	blobManager     *y.Closer
+	memtable        *y.Closer
+	writes          *y.Closer
 }
 
 // DB provides the various functions required to interact with Badger.
@@ -83,9 +85,10 @@ type DB struct {
 	blockCache *cache.Cache
 	indexCache *cache.Cache
 
-	metrics  *y.MetricsSet
-	lsmSize  int64
-	vlogSize int64
+	metrics      *y.MetricsSet
+	lsmSize      int64
+	vlogSize     int64
+	volatileMode bool
 
 	blobManger blobManager
 
@@ -306,6 +309,7 @@ func Open(opt Options) (db *DB, err error) {
 		metrics:       y.NewMetricSet(opt.Dir),
 		blockCache:    blkCache,
 		indexCache:    idxCache,
+		volatileMode:  opt.VolatileMode,
 	}
 	db.vlog.metrics = db.metrics
 
@@ -333,7 +337,8 @@ func Open(opt Options) (db *DB, err error) {
 	go db.updateSize(db.closers.updateSize)
 	db.mtbls.Store(newMemTables(<-db.memTableCh, &memTables{}))
 
-	db.resourceMgr = epoch.NewResourceManager(&db.safeTsTracker)
+	db.closers.resourceManager = y.NewCloser(0)
+	db.resourceMgr = epoch.NewResourceManager(db.closers.resourceManager, &db.safeTsTracker)
 
 	// newLevelsController potentially loads files in directory.
 	if db.lc, err = newLevelsController(db, &manifest, db.resourceMgr, opt.TableBuilderOptions); err != nil {
@@ -570,7 +575,7 @@ func (db *DB) Close() (err error) {
 	// trying to push stuff into the memtable. This will also resolve the value
 	// offset problem: as we push into memtable, we update value offsets there.
 	mTbls := db.mtbls.Load().(*memTables)
-	if !mTbls.getMutable().Empty() {
+	if !mTbls.getMutable().Empty() && !db.volatileMode {
 		log.Infof("Flushing memtable")
 		db.mtbls.Store(newMemTables(nil, mTbls))
 		db.flushChan <- newFlushTask(mTbls.getMutable(), db.logOff)
@@ -585,7 +590,15 @@ func (db *DB) Close() (err error) {
 		db.closers.compactors.SignalAndWait()
 		log.Infof("Compaction finished")
 	}
-	if db.opt.CompactL0WhenClose {
+	if db.closers.blobManager != nil {
+		db.closers.blobManager.SignalAndWait()
+		log.Infof("BlobManager finished")
+	}
+	if db.closers.resourceManager != nil {
+		db.closers.resourceManager.SignalAndWait()
+		log.Infof("ResourceManager finished")
+	}
+	if db.opt.CompactL0WhenClose && !db.volatileMode {
 		// Force Compact L0
 		// We don't need to care about cstatus since no parallel compaction is running.
 		cd := &compactDef{

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -196,7 +196,9 @@ func TestOverlappingKeyRangeError(t *testing.T) {
 		nextLevel: lh1,
 	}
 
-	rm := epoch.NewResourceManager(epoch.NoOpInspector{})
+	closer := y.NewCloser(0)
+	defer closer.SignalAndWait()
+	rm := epoch.NewResourceManager(closer, epoch.NoOpInspector{})
 	g := rm.Acquire()
 	defer g.Done()
 	manifest := createManifest()

--- a/options.go
+++ b/options.go
@@ -86,6 +86,7 @@ type Options struct {
 
 	// 4. Flags for testing purposes
 	// ------------------------------
+	VolatileMode bool
 	DoNotCompact bool // Stops LSM tree from compactions.
 
 	maxBatchCount int64 // max entries in batch


### PR DESCRIPTION
Fix goroutine leak in TiDB's unit tests.
Provide a `VolatileMode` to reduce the disk usages when use it in TiDB's unit tests.